### PR TITLE
Korablev Nikita. Lab №1. Option №4.

### DIFF
--- a/clang/labs/lab1/korablev_nikita/CMakeLists.txt
+++ b/clang/labs/lab1/korablev_nikita/CMakeLists.txt
@@ -1,14 +1,14 @@
 add_llvm_library(RenamedIdPlugin MODULE RenameIdentificator.cpp PLUGIN_TOOL clang)
 
-set(LLVM_LINK_COMPONENTS
-  Support
-)
-clang_target_link_libraries(RenamedIdPlugin PRIVATE
-  clangAST
-  clangBasic
-  clangFrontend
-  clangTooling
-  clangTransformer
-)
+if(WIN32 OR CYGWIN)
+  set(LLVM_LINK_COMPONENTS
+    Support
+  )
+  clang_target_link_libraries(DeprecatedWarningPlugin PRIVATE
+    clangAST
+    clangBasic
+    clangFrontend
+  )
+endif()
 
 set(CLANG_TEST_DEPS "RenamedIdPlugin" ${CLANG_TEST_DEPS} PARENT_SCOPE)

--- a/clang/labs/lab1/korablev_nikita/CMakeLists.txt
+++ b/clang/labs/lab1/korablev_nikita/CMakeLists.txt
@@ -1,0 +1,16 @@
+add_llvm_library(RenamedIdPlugin MODULE RenameIdentificator.cpp PLUGIN_TOOL clang)
+
+if(WIN32 OR CYGWIN)
+  set(LLVM_LINK_COMPONENTS
+    Support
+  )
+  clang_target_link_libraries(RenamedIdPlugin PRIVATE
+    clangAST
+    clangBasic
+    clangFrontend
+    clangTooling
+    clangTransformer
+    )
+endif()
+
+set(CLANG_TEST_DEPS "RenamedIdPlugin" ${CLANG_TEST_DEPS} PARENT_SCOPE)

--- a/clang/labs/lab1/korablev_nikita/CMakeLists.txt
+++ b/clang/labs/lab1/korablev_nikita/CMakeLists.txt
@@ -1,16 +1,14 @@
 add_llvm_library(RenamedIdPlugin MODULE RenameIdentificator.cpp PLUGIN_TOOL clang)
 
-if(WIN32 OR CYGWIN)
-  set(LLVM_LINK_COMPONENTS
-    Support
-  )
-  clang_target_link_libraries(RenamedIdPlugin PRIVATE
-    clangAST
-    clangBasic
-    clangFrontend
-    clangTooling
-    clangTransformer
-    )
-endif()
+set(LLVM_LINK_COMPONENTS
+  Support
+)
+clang_target_link_libraries(RenamedIdPlugin PRIVATE
+  clangAST
+  clangBasic
+  clangFrontend
+  clangTooling
+  clangTransformer
+)
 
 set(CLANG_TEST_DEPS "RenamedIdPlugin" ${CLANG_TEST_DEPS} PARENT_SCOPE)

--- a/clang/labs/lab1/korablev_nikita/RenameIdentificator.cpp
+++ b/clang/labs/lab1/korablev_nikita/RenameIdentificator.cpp
@@ -1,0 +1,76 @@
+#include "clang/AST/ASTConsumer.h"
+#include "clang/AST/RecursiveASTVisitor.h"
+#include "clang/Frontend/CompilerInstance.h"
+#include "clang/Frontend/FrontendPluginRegistry.h"
+#include "clang/Rewrite/Core/Rewriter.h"
+#include "llvm/Support/raw_ostream.h"
+
+#include "clang/Tooling/Transformer/RewriteRule.h"
+#include "clang/Tooling/Transformer/Stencil.h"
+
+
+using namespace clang;
+using namespace clang::ast_matchers;
+using namespace clang::transformer;
+
+using ::clang::transformer::changeTo;
+using ::clang::transformer::makeRule;
+using ::clang::transformer::node;
+using ::clang::transformer::RewriteRuleWith;
+
+
+class RenameVisitor: public RecursiveASTVisitor<RenameVisitor> {
+private:
+    Rewriter rewriter;
+    StringRef oldName;
+    StringRef newName;
+public:
+    explicit RenameVisitor(Rewriter Rewriter, StringRef OldName,
+                                 StringRef NewName) : rewriter(Rewriter), oldName(OldName), newName(NewName) {};
+
+    bool VisitFunctionDecl(FunctionDecl *FD) {
+        llvm::outs() << FD->getName() << " | ";
+        // if (FD->getNameAsString() == oldName) {
+        //     rewriter.ReplaceText(FD->getNameInfo().getSourceRange(), newName);
+        //     rewriter.overwriteChangedFiles();
+        // }
+
+
+        llvm::outs() << FD->getName() << "\n";
+        return true;
+    }
+};
+
+class RenameIdConsumer : public ASTConsumer {
+    RenameVisitor visitor;
+public:
+    explicit RenameIdConsumer(CompilerInstance &CI, StringRef oldName, StringRef newName): 
+                visitor(clang::Rewriter(CI.getSourceManager(), CI.getLangOpts()), oldName, newName) {}
+
+    void HandleTranslationUnit(ASTContext &Context) override {
+        visitor.TraverseDecl(Context.getTranslationUnitDecl());
+
+        makeRule(declRefExpr(to(functionDecl(hasName("sum")))),
+                changeTo(cat("renamed")),
+                cat("'sum' has been renamed 'renamed'"));
+    }
+};
+
+
+class RenameIdPlugin: public clang::PluginASTAction {
+private:
+    std::vector<std::string> s = {"sum", "renamed"};
+    std::string OldName = s[0];
+    std::string NewName = s[1];
+protected:
+    bool ParseArgs(const clang::CompilerInstance &Compiler,
+        const std::vector<std::string> &args) override { return true; }
+public:
+    std::unique_ptr<clang::ASTConsumer> CreateASTConsumer (
+            clang::CompilerInstance &Compiler, llvm::StringRef InFile) override {
+        return std::make_unique<RenameIdConsumer>(Compiler, OldName, NewName);
+    }
+};
+
+static FrontendPluginRegistry::Add<RenameIdPlugin>
+X("renamed-id", "Idetificator was renamed.");

--- a/clang/labs/lab1/korablev_nikita/RenameIdentificator.cpp
+++ b/clang/labs/lab1/korablev_nikita/RenameIdentificator.cpp
@@ -22,51 +22,151 @@ using ::clang::transformer::makeRule;
 using ::clang::transformer::RewriteRuleWith;
 
 
+
 class RenameVisitor: public RecursiveASTVisitor<RenameVisitor> {
 private:
     Rewriter rewriter;
-    StringRef oldName;
-    StringRef newName;
+    std::string oldName;
+    std::string newName;
 public:
-    explicit RenameVisitor(Rewriter Rewriter, StringRef OldName,
-                                 StringRef NewName) : rewriter(Rewriter), oldName(OldName), newName(NewName) {};
+    explicit RenameVisitor(Rewriter Rewriter, std::string OldName,
+                                 std::string NewName) : rewriter(Rewriter), oldName(OldName), newName(NewName) {};
 
     bool VisitFunctionDecl(FunctionDecl *FD) {
-        llvm::outs() << FD->getName() << " | ";
-        // if (FD->getNameAsString() == oldName) {
-        //     rewriter.ReplaceText(FD->getNameInfo().getSourceRange(), newName);
-        //     rewriter.overwriteChangedFiles();
-        // }
+        std::string name = FD->getNameAsString();
 
+        llvm::outs() << "FunctionDecl: " << name <<"\n";
+        if (name == oldName) {
+            rewriter.ReplaceText(FD->getNameInfo().getSourceRange(), newName);
+            rewriter.overwriteChangedFiles();
+        }
 
-        llvm::outs() << FD->getName() << "\n";
         return true;
     }
+
+    bool VisitDeclRefExpr(DeclRefExpr *DRE) {
+        std::string name = DRE->getNameInfo().getAsString();
+
+        llvm::outs() << "DeclRefExpr: " << name <<"\n";
+        if (name == oldName) {
+            rewriter.ReplaceText(DRE->getNameInfo().getSourceRange(), newName);
+            rewriter.overwriteChangedFiles();
+        }
+
+        return true;
+    }
+
+    // bool VisitCallExpr(CallExpr *CE) {
+    //     // llvm::outs() << oldName <<"\n";
+    //     // const DeclContext *ParentContext = DRE->getDecl()->getDeclContext();
+    //     // llvm::outs() << !isa<CXXRecordDecl>(ParentContext) <<"\n";
+    //     std::string name = CE->getDirectCallee()->getNameAsString();
+    //     if (name.find(concSt) != std::string::npos) return true;
+
+    //     llvm::outs() << "CallExpr: " << name <<"\n";
+    //     if (oldName == "" || newName == "") esRename(std::string(name));
+    //     else if (name != oldName) return true;
+
+    //     rewriter.ReplaceText(CE->getCallee()->getSourceRange(), newName);
+    //     rewriter.overwriteChangedFiles();
+
+    //     return true;
+    // }
+
+    // bool VisitParmVarDecl(ParmVarDecl *PVD) {
+    //     // const DeclContext *ParentContext = PVD->getParentFunctionOrMethod()->getParent();
+    //     // llvm::outs() << !isa<CXXRecordDecl>(ParentContext) <<"\n";
+    //     std::string name = PVD->getNameAsString();
+    //     if (name.find(concSt) != std::string::npos) return true;
+
+    //     llvm::outs() << "ParmVarDecl: " << name <<"\n";
+    //     if (oldName == "" || newName == "") esRename(name);
+    //     else if (name != oldName) return true;
+
+    //     rewriter.ReplaceText(PVD->getLocation(), name.size(), newName);
+    //     rewriter.overwriteChangedFiles();
+
+    //     return true;
+    // }
+
+    bool VisitVarDecl(VarDecl *VD) {
+        const DeclContext *ParentContext = VD->getParentFunctionOrMethod()->getParent();
+        llvm::outs() << VD->getType().getAsString() <<"\n";
+
+        std::string name = VD->getNameAsString();
+
+        llvm::outs() << "VarDecl: " << name <<"\n";
+        if (name == oldName) {
+            rewriter.ReplaceText(VD->getLocation(), name.size(), newName);
+            rewriter.overwriteChangedFiles();
+        }
+
+        return true;
+    }
+
+    bool VisitCXXRecordDecl(CXXRecordDecl *CRD) {
+        std::string name = CRD->getNameAsString();
+
+        llvm::outs() << "CXXRecordDecl: " << name <<"\n";
+        if (name != oldName) {
+            rewriter.ReplaceText(CRD->getLocation(), name.size(), newName);
+            rewriter.overwriteChangedFiles();
+        }
+
+        return true;
+    }
+
+    bool VisitCXXNewExpr(CXXNewExpr *CXXNE) {
+        std::string name = CXXNE->getConstructExpr()->getType().getAsString();
+
+        llvm::outs() << "CXXRecordDecl: " << name <<"\n";
+        if (name == oldName) {
+            rewriter.ReplaceText(CXXNE->getExprLoc(), name.size() + 4, "new " + newName);
+            rewriter.overwriteChangedFiles();
+        }
+
+        return true;
+    }
+
 };
 
 class RenameIdConsumer : public ASTConsumer {
     RenameVisitor visitor;
 public:
-    explicit RenameIdConsumer(CompilerInstance &CI, StringRef oldName, StringRef newName): 
+    explicit RenameIdConsumer(CompilerInstance &CI, std::string oldName, std::string newName): 
                 visitor(clang::Rewriter(CI.getSourceManager(), CI.getLangOpts()), oldName, newName) {}
 
     void HandleTranslationUnit(ASTContext &Context) override {
         visitor.TraverseDecl(Context.getTranslationUnitDecl());
 
-        makeRule(declRefExpr(to(functionDecl(hasName("sum")))),
-                changeTo(cat("renamed")),
-                cat("'sum' has been renamed 'renamed'"));
+        // makeRule(declRefExpr(to(functionDecl(hasName("sum")))),
+        //         changeTo(cat("renamed")),
+        //         cat("'sum' has been renamed 'renamed'"));
     }
 };
 
 class RenameIdPlugin: public clang::PluginASTAction {
 private:
-    std::vector<std::string> s = {"sum", "renamed"};
-    std::string OldName = s[0];
-    std::string NewName = s[1];
+    std::string OldName = "";
+    std::string NewName = "";
 protected:
     bool ParseArgs(const clang::CompilerInstance &Compiler,
-        const std::vector<std::string> &args) override { return true; }
+        const std::vector<std::string> &args) override {
+            OldName = args[0];
+            NewName = args[1];
+
+            if (OldName.find("=") == 0 || OldName.find("=") == std::string::npos) {
+                llvm::errs() << "Error entering the `OldName` parameter." << "\n";
+            }
+            if (NewName.find("=") == 0 || NewName.find("=") == std::string::npos) {
+                llvm::errs() << "Error entering the `NewName` parameter." << "\n";
+            }
+
+            OldName = OldName.substr(OldName.find("=") + 1);
+            NewName = NewName.substr(NewName.find("=") + 1);
+
+            return true;
+        }
 public:
     std::unique_ptr<clang::ASTConsumer> CreateASTConsumer (
             clang::CompilerInstance &Compiler, llvm::StringRef InFile) override {

--- a/clang/labs/lab1/korablev_nikita/RenameIdentificator.cpp
+++ b/clang/labs/lab1/korablev_nikita/RenameIdentificator.cpp
@@ -4,122 +4,137 @@
 #include "clang/Frontend/FrontendPluginRegistry.h"
 #include "clang/Rewrite/Core/Rewriter.h"
 
-#include "llvm/Support/raw_ostream.h"
 #include "llvm/ADT/StringRef.h"
+#include "llvm/Support/raw_ostream.h"
 
-class RenameVisitor: public clang::RecursiveASTVisitor<RenameVisitor> {
+class RenameVisitor : public clang::RecursiveASTVisitor<RenameVisitor> {
 private:
-    clang::Rewriter rewriter;
-    std::string oldName;
-    std::string newName;
+  clang::Rewriter rewriter;
+  std::string oldName;
+  std::string newName;
+
 public:
-    explicit RenameVisitor(clang::Rewriter Rewriter, std::string OldName,
-                                 std::string NewName) : rewriter(Rewriter), oldName(OldName), newName(NewName) {};
+  explicit RenameVisitor(clang::Rewriter Rewriter, std::string OldName,
+                         std::string NewName)
+      : rewriter(Rewriter), oldName(OldName), newName(NewName){};
 
-    bool VisitFunctionDecl(clang::FunctionDecl *FD) {
-        std::string name = FD->getNameAsString();
-        
-        if (name == oldName) {
-            rewriter.ReplaceText(FD->getNameInfo().getSourceRange(), newName);
-            rewriter.overwriteChangedFiles();
-        }
+  bool VisitFunctionDecl(clang::FunctionDecl *FD) {
+    std::string name = FD->getNameAsString();
 
-        return true;
+    if (name == oldName) {
+      rewriter.ReplaceText(FD->getNameInfo().getSourceRange(), newName);
+      rewriter.overwriteChangedFiles();
     }
 
-    bool VisitDeclRefExpr(clang::DeclRefExpr *DRE) {
-        std::string name = DRE->getNameInfo().getAsString();
+    return true;
+  }
 
-        if (name == oldName) {
-            rewriter.ReplaceText(DRE->getNameInfo().getSourceRange(), newName);
-            rewriter.overwriteChangedFiles();
-        }
+  bool VisitDeclRefExpr(clang::DeclRefExpr *DRE) {
+    std::string name = DRE->getNameInfo().getAsString();
 
-        return true;
+    if (name == oldName) {
+      rewriter.ReplaceText(DRE->getNameInfo().getSourceRange(), newName);
+      rewriter.overwriteChangedFiles();
     }
 
-    bool VisitVarDecl(clang::VarDecl *VD) {
-        std::string name = VD->getNameAsString();
+    return true;
+  }
 
-        if (name == oldName) {
-            rewriter.ReplaceText(VD->getLocation(), name.size(), newName);
-            rewriter.overwriteChangedFiles();
-        }
+  bool VisitVarDecl(clang::VarDecl *VD) {
+    std::string name = VD->getNameAsString();
 
-        if (VD->getType().getAsString() == oldName + " *" || VD->getType().getAsString() == oldName) {
-            rewriter.ReplaceText(VD->getTypeSourceInfo()->getTypeLoc().getBeginLoc(), name.size(), newName);
-            rewriter.overwriteChangedFiles();
-        }
-
-        return true;
+    if (name == oldName) {
+      rewriter.ReplaceText(VD->getLocation(), name.size(), newName);
+      rewriter.overwriteChangedFiles();
     }
 
-    bool VisitCXXRecordDecl(clang::CXXRecordDecl *CXXRD) {
-        std::string name = CXXRD->getNameAsString();
-
-        if (name == oldName) {
-            rewriter.ReplaceText(CXXRD->getLocation(), name.size(), newName);
-
-            const clang::CXXDestructorDecl *CXXDD = CXXRD->getDestructor();
-            if (CXXDD) rewriter.ReplaceText(CXXDD->getLocation(), name.size() + 1, "~" + newName);
-
-            rewriter.overwriteChangedFiles();
-        }
-
-        return true;
+    if (VD->getType().getAsString() == oldName + " *" ||
+        VD->getType().getAsString() == oldName) {
+      rewriter.ReplaceText(VD->getTypeSourceInfo()->getTypeLoc().getBeginLoc(),
+                           name.size(), newName);
+      rewriter.overwriteChangedFiles();
     }
 
-    bool VisitCXXNewExpr(clang::CXXNewExpr *CXXNE) {
-        std::string name = CXXNE->getConstructExpr()->getType().getAsString();
+    return true;
+  }
 
-        if (name == oldName) {
-            rewriter.ReplaceText(CXXNE->getExprLoc(), name.size() + 4, "new " + newName);
-            rewriter.overwriteChangedFiles();
-        }
+  bool VisitCXXRecordDecl(clang::CXXRecordDecl *CXXRD) {
+    std::string name = CXXRD->getNameAsString();
 
-        return true;
+    if (name == oldName) {
+      rewriter.ReplaceText(CXXRD->getLocation(), name.size(), newName);
+
+      const clang::CXXDestructorDecl *CXXDD = CXXRD->getDestructor();
+      if (CXXDD)
+        rewriter.ReplaceText(CXXDD->getLocation(), name.size() + 1,
+                             "~" + newName);
+
+      rewriter.overwriteChangedFiles();
     }
+
+    return true;
+  }
+
+  bool VisitCXXNewExpr(clang::CXXNewExpr *CXXNE) {
+    std::string name = CXXNE->getConstructExpr()->getType().getAsString();
+
+    if (name == oldName) {
+      rewriter.ReplaceText(CXXNE->getExprLoc(), name.size() + 4,
+                           "new " + newName);
+      rewriter.overwriteChangedFiles();
+    }
+
+    return true;
+  }
 };
 
 class RenameIdConsumer : public clang::ASTConsumer {
-    RenameVisitor visitor;
-public:
-    explicit RenameIdConsumer(clang::CompilerInstance &CI, std::string oldName, std::string newName): 
-                visitor(clang::Rewriter(CI.getSourceManager(), CI.getLangOpts()), oldName, newName) {}
+  RenameVisitor visitor;
 
-    void HandleTranslationUnit(clang::ASTContext &Context) override {
-        visitor.TraverseDecl(Context.getTranslationUnitDecl());
-    }
+public:
+  explicit RenameIdConsumer(clang::CompilerInstance &CI, std::string oldName,
+                            std::string newName)
+      : visitor(clang::Rewriter(CI.getSourceManager(), CI.getLangOpts()),
+                oldName, newName) {}
+
+  void HandleTranslationUnit(clang::ASTContext &Context) override {
+    visitor.TraverseDecl(Context.getTranslationUnitDecl());
+  }
 };
 
-class RenameIdPlugin: public clang::PluginASTAction {
+class RenameIdPlugin : public clang::PluginASTAction {
 private:
-    std::string OldName;
-    std::string NewName;
+  std::string OldName;
+  std::string NewName;
+
 protected:
-    bool ParseArgs(const clang::CompilerInstance &Compiler,
-        const std::vector<std::string> &args) override {
-            OldName = args[0];
-            NewName = args[1];
+  bool ParseArgs(const clang::CompilerInstance &Compiler,
+                 const std::vector<std::string> &args) override {
+    OldName = args[0];
+    NewName = args[1];
 
-            if (OldName.find("=") == 0 || OldName.find("=") == std::string::npos) {
-                llvm::errs() << "Error entering the `OldName` parameter." << "\n";
-            }
-            if (NewName.find("=") == 0 || NewName.find("=") == std::string::npos) {
-                llvm::errs() << "Error entering the `NewName` parameter." << "\n";
-            }
-
-            OldName = OldName.substr(OldName.find("=") + 1);
-            NewName = NewName.substr(NewName.find("=") + 1);
-
-            return true;
-        }
-public:
-    std::unique_ptr<clang::ASTConsumer> CreateASTConsumer (
-            clang::CompilerInstance &Compiler, llvm::StringRef InFile) override {
-        return std::make_unique<RenameIdConsumer>(Compiler, OldName, NewName);
+    if (OldName.find("=") == 0 || OldName.find("=") == std::string::npos) {
+      llvm::errs() << "Error entering the `OldName` parameter."
+                   << "\n";
     }
+    if (NewName.find("=") == 0 || NewName.find("=") == std::string::npos) {
+      llvm::errs() << "Error entering the `NewName` parameter."
+                   << "\n";
+    }
+
+    OldName = OldName.substr(OldName.find("=") + 1);
+    NewName = NewName.substr(NewName.find("=") + 1);
+
+    return true;
+  }
+
+public:
+  std::unique_ptr<clang::ASTConsumer>
+  CreateASTConsumer(clang::CompilerInstance &Compiler,
+                    llvm::StringRef InFile) override {
+    return std::make_unique<RenameIdConsumer>(Compiler, OldName, NewName);
+  }
 };
 
 static clang::FrontendPluginRegistry::Add<RenameIdPlugin>
-X("renamed-id", "Idetificator was renamed.");
+    X("renamed-id", "Idetificator was renamed.");

--- a/clang/labs/lab1/korablev_nikita/RenameIdentificator.cpp
+++ b/clang/labs/lab1/korablev_nikita/RenameIdentificator.cpp
@@ -9,79 +9,79 @@
 
 class RenameVisitor : public clang::RecursiveASTVisitor<RenameVisitor> {
 private:
-  clang::Rewriter rewriter;
-  std::string oldName;
-  std::string newName;
+  clang::Rewriter Rewriter;
+  std::string OldName;
+  std::string NewName;
 
 public:
   explicit RenameVisitor(clang::Rewriter Rewriter, std::string OldName,
                          std::string NewName)
-      : rewriter(Rewriter), oldName(OldName), newName(NewName){};
+      : Rewriter(Rewriter), OldName(OldName), NewName(NewName){};
 
   bool VisitFunctionDecl(clang::FunctionDecl *FD) {
-    std::string name = FD->getNameAsString();
+    std::string Name = FD->getNameAsString();
 
-    if (name == oldName) {
-      rewriter.ReplaceText(FD->getNameInfo().getSourceRange(), newName);
-      rewriter.overwriteChangedFiles();
+    if (Name == OldName) {
+      Rewriter.ReplaceText(FD->getNameInfo().getSourceRange(), NewName);
+      Rewriter.overwriteChangedFiles();
     }
 
     return true;
   }
 
   bool VisitDeclRefExpr(clang::DeclRefExpr *DRE) {
-    std::string name = DRE->getNameInfo().getAsString();
+    std::string Name = DRE->getNameInfo().getAsString();
 
-    if (name == oldName) {
-      rewriter.ReplaceText(DRE->getNameInfo().getSourceRange(), newName);
-      rewriter.overwriteChangedFiles();
+    if (Name == OldName) {
+      Rewriter.ReplaceText(DRE->getNameInfo().getSourceRange(), NewName);
+      Rewriter.overwriteChangedFiles();
     }
 
     return true;
   }
 
   bool VisitVarDecl(clang::VarDecl *VD) {
-    std::string name = VD->getNameAsString();
+    std::string Name = VD->getNameAsString();
 
-    if (name == oldName) {
-      rewriter.ReplaceText(VD->getLocation(), name.size(), newName);
-      rewriter.overwriteChangedFiles();
+    if (Name == OldName) {
+      Rewriter.ReplaceText(VD->getLocation(), Name.size(), NewName);
+      Rewriter.overwriteChangedFiles();
     }
 
-    if (VD->getType().getAsString() == oldName + " *" ||
-        VD->getType().getAsString() == oldName) {
-      rewriter.ReplaceText(VD->getTypeSourceInfo()->getTypeLoc().getBeginLoc(),
-                           name.size(), newName);
-      rewriter.overwriteChangedFiles();
+    if (VD->getType().getAsString() == OldName + " *" ||
+        VD->getType().getAsString() == OldName) {
+      Rewriter.ReplaceText(VD->getTypeSourceInfo()->getTypeLoc().getBeginLoc(),
+                           Name.size(), NewName);
+      Rewriter.overwriteChangedFiles();
     }
 
     return true;
   }
 
   bool VisitCXXRecordDecl(clang::CXXRecordDecl *CXXRD) {
-    std::string name = CXXRD->getNameAsString();
+    std::string Name = CXXRD->getNameAsString();
 
-    if (name == oldName) {
-      rewriter.ReplaceText(CXXRD->getLocation(), name.size(), newName);
+    if (Name == OldName) {
+      Rewriter.ReplaceText(CXXRD->getLocation(), Name.size(), NewName);
 
       const clang::CXXDestructorDecl *CXXDD = CXXRD->getDestructor();
       if (CXXDD)
-        rewriter.ReplaceText(CXXDD->getLocation(), name.size() + 1,
-                             "~" + newName);
+        Rewriter.ReplaceText(CXXDD->getLocation(), Name.size() + 1,
+                             "~" + NewName);
 
-      rewriter.overwriteChangedFiles();
+      Rewriter.overwriteChangedFiles();
     }
 
     return true;
   }
 
   bool VisitCXXNewExpr(clang::CXXNewExpr *CXXNE) {
-    std::string name = CXXNE->getConstructExpr()->getType().getAsString();
+    std::string Name = CXXNE->getConstructExpr()->getType().getAsString();
 
-    if (name == oldName) {
-      rewriter.ReplaceText(CXXNE->getExprLoc(), name.size() + 4,
-                           "new " + newName);
-      rewriter.overwriteChangedFiles();
+    if (Name == OldName) {
+      Rewriter.ReplaceText(CXXNE->getExprLoc(), Name.size() + 4,
+                           "new " + NewName);
+      Rewriter.overwriteChangedFiles();
     }
 
     return true;
@@ -92,10 +92,10 @@ class RenameIdConsumer : public clang::ASTConsumer {
   RenameVisitor visitor;
 
 public:
-  explicit RenameIdConsumer(clang::CompilerInstance &CI, std::string oldName,
-                            std::string newName)
+  explicit RenameIdConsumer(clang::CompilerInstance &CI, std::string OldName,
+                            std::string NewName)
       : visitor(clang::Rewriter(CI.getSourceManager(), CI.getLangOpts()),
-                oldName, newName) {}
+                OldName, NewName) {}
 
   void HandleTranslationUnit(clang::ASTContext &Context) override {
     visitor.TraverseDecl(Context.getTranslationUnitDecl());

--- a/clang/labs/lab1/korablev_nikita/RenameIdentificator.cpp
+++ b/clang/labs/lab1/korablev_nikita/RenameIdentificator.cpp
@@ -3,11 +3,15 @@
 #include "clang/Frontend/CompilerInstance.h"
 #include "clang/Frontend/FrontendPluginRegistry.h"
 #include "clang/Rewrite/Core/Rewriter.h"
+
 #include "llvm/Support/raw_ostream.h"
+#include "llvm/ADT/StringRef.h"
 
+#include "clang/ASTMatchers/ASTMatchFinder.h"
+#include "clang/ASTMatchers/ASTMatchers.h"
 #include "clang/Tooling/Transformer/RewriteRule.h"
+#include "clang/Tooling/Transformer/Transformer.h"
 #include "clang/Tooling/Transformer/Stencil.h"
-
 
 using namespace clang;
 using namespace clang::ast_matchers;
@@ -15,7 +19,6 @@ using namespace clang::transformer;
 
 using ::clang::transformer::changeTo;
 using ::clang::transformer::makeRule;
-using ::clang::transformer::node;
 using ::clang::transformer::RewriteRuleWith;
 
 
@@ -55,7 +58,6 @@ public:
                 cat("'sum' has been renamed 'renamed'"));
     }
 };
-
 
 class RenameIdPlugin: public clang::PluginASTAction {
 private:

--- a/clang/test/lab1/korablev_nikita/example.cpp
+++ b/clang/test/lab1/korablev_nikita/example.cpp
@@ -13,5 +13,7 @@ int sum(int a, int b) {
 
 void func2() {
     A* a = new A;
+    A b;
+
     delete a;
 };

--- a/clang/test/lab1/korablev_nikita/example.cpp
+++ b/clang/test/lab1/korablev_nikita/example.cpp
@@ -1,3 +1,17 @@
-int sun(int a, int b) {
+class A {
+public:
+    A() {};
+    ~A();
+};
+
+int sum(int a, int b) {
+    int c = sum(1, 2);
+    c++;
+    a += b;
     return a+b;
+};
+
+void func2() {
+    A* a = new A;
+    delete a;
 };

--- a/clang/test/lab1/korablev_nikita/example.cpp
+++ b/clang/test/lab1/korablev_nikita/example.cpp
@@ -1,19 +1,84 @@
+// RUN: split-file %s %t
+// RUN: %clang_cc1 -load %llvmshlibdir/RenamedIdPlugin%pluginext -add-plugin renamed-id\
+// RUN: -plugin-arg-renamed-id OldName="A"\
+// RUN: -plugin-arg-renamed-id NewName="B" %t/test_1.cpp
+// RUN: FileCheck %s < %t/test_1.cpp --check-prefix=CLASS-CHECK
+
+// CLASS-CHECK: class B {
+// CLASS-CHECK-NEXT: public:
+// CLASS-CHECK-NEXT:     B() {};
+// CLASS-CHECK-NEXT:     ~B();
+// CLASS-CHECK-NEXT: };
+// CLASS-CHECK-NEXT: void func() {
+// CLASS-CHECK-NEXT:     B* a = new B;
+// CLASS-CHECK-NEXT:     B b;
+// CLASS-CHECK-NEXT:     delete a;
+// CLASS-CHECK-NEXT: };
+
+//--- test_1.cpp
 class A {
 public:
     A() {};
     ~A();
 };
+void func() {
+    A* a = new A;
+    A b;
+    delete a;
+};
 
+// RUN: %clang_cc1 -load %llvmshlibdir/RenamedIdPlugin%pluginext -add-plugin renamed-id\
+// RUN: -plugin-arg-renamed-id OldName="A"\
+// RUN: -plugin-arg-renamed-id NewName="B" %t/test_2.cpp
+// RUN: FileCheck %s < %t/test_2.cpp --check-prefix=SUM-CHECK
+
+// SUM-CHECK: int sum(int a, int b) {
+// SUM-CHECK-NEXT:     int c = sum(1, 2);
+// SUM-CHECK-NEXT:     c++; 
+// SUM-CHECK-NEXT:     a += b;
+// SUM-CHECK-NEXT:     return a+b;
+// SUM-CHECK-NEXT: };
+
+//--- test_2.cpp
 int sum(int a, int b) {
     int c = sum(1, 2);
-    c++;
+    c++; 
     a += b;
     return a+b;
 };
 
-void func2() {
-    A* a = new A;
-    A b;
+// RUN: %clang_cc1 -load %llvmshlibdir/RenamedIdPlugin%pluginext -add-plugin renamed-id\
+// RUN: -plugin-arg-renamed-id OldName="C"\
+// RUN: -plugin-arg-renamed-id NewName="Renamed_C" %t/test_3.cpp
+// RUN: FileCheck %s < %t/test_3.cpp --check-prefix=CLASS2-CHECK
 
-    delete a;
+// CLASS2-CHECK: class Renamed_C {
+// CLASS2-CHECK-NEXT: private:
+// CLASS2-CHECK-NEXT:     int a;
+// CLASS2-CHECK-NEXT:     int b;
+// CLASS2-CHECK-NEXT: public:
+// CLASS2-CHECK-NEXT:     Renamed_C() {}
+// CLASS2-CHECK-NEXT:     Renamed_C(int a, int b): a(a), b(b) {}
+// CLASS2-CHECK-NEXT:     ~Renamed_C();
+// CLASS2-CHECK-NEXT: };
+// CLASS2-CHECK-NEXT: void func() {
+// CLASS2-CHECK-NEXT:     Renamed_C a;
+// CLASS2-CHECK-NEXT:     Renamed_C* b = new Renamed_C(1, 2);
+// CLASS2-CHECK-NEXT:     delete b;
+// CLASS2-CHECK-NEXT: }
+
+//--- test_3.cpp
+class C {
+private:
+    int a;
+    int b;
+public:
+    C() {}
+    C(int a, int b): a(a), b(b) {}
+    ~C();
+};
+void func() {
+    C a;
+    C* b = new C(1, 2);
+    delete b;
 };

--- a/clang/test/lab1/korablev_nikita/example.cpp
+++ b/clang/test/lab1/korablev_nikita/example.cpp
@@ -1,3 +1,3 @@
-int sum(int a, int b) {
+int sun(int a, int b) {
     return a+b;
 };

--- a/clang/test/lab1/korablev_nikita/example.cpp
+++ b/clang/test/lab1/korablev_nikita/example.cpp
@@ -1,0 +1,3 @@
+int sum(int a, int b) {
+    return a+b;
+};


### PR DESCRIPTION
A plugin has been implemented that renames identifiers (variable name, class name, function name).
Example:
```c++
class A {
public:
    A() {};
    ~A();
};
void func() {
    A* a = new A;
    A b;
    delete a;
};
```
Result:
```c++
class B {
public:
    B() {};
    ~B();
};
void func() {
    B* a = new B;
    B b;
    delete a;
 };
```