### PR TITLE
Kulagin Aleksandr / lab1 / var 2

### DIFF
--- a/clang/labs/lab1/kulagin_aleksandr/CMakeLists.txt
+++ b/clang/labs/lab1/kulagin_aleksandr/CMakeLists.txt
@@ -1,0 +1,14 @@
+add_llvm_library(kulaginAlwaysInline MODULE alwaysInline.cpp PLUGIN_TOOL clang)
+
+if(WIN32 OR CYGWIN)
+  set(LLVM_LINK_COMPONENTS
+      Support
+  )
+  clang_target_link_libraries(kulaginAlwaysInline PRIVATE
+    clangAST
+    clangBasic
+    clangFrontend
+    )
+endif()
+
+set(CLANG_TEST_DEPS "kulaginAlwaysInline" ${CLANG_TEST_DEPS} PARENT_SCOPE)

--- a/clang/labs/lab1/kulagin_aleksandr/alwaysInline.cpp
+++ b/clang/labs/lab1/kulagin_aleksandr/alwaysInline.cpp
@@ -24,9 +24,11 @@ namespace {
           if (body != nullptr) {
             bool cond_found = false;
             for (clang::Stmt* st : body->children()) {
-              if (clang::isa<clang::IfStmt>(st) ||
-              clang::isa<clang::WhileStmt>(st) || clang::isa<clang::ForStmt>(st)
-              || clang::isa<clang::DoStmt>(st)) {
+              if (clang::isa<clang::IfStmt>(st)
+              || clang::isa<clang::WhileStmt>(st)
+              || clang::isa<clang::ForStmt>(st)
+              || clang::isa<clang::DoStmt>(st)
+              || clang::isa<clang::SwitchStmt>(st)) {
                 cond_found = true;
                 break;
               }

--- a/clang/labs/lab1/kulagin_aleksandr/alwaysInline.cpp
+++ b/clang/labs/lab1/kulagin_aleksandr/alwaysInline.cpp
@@ -69,7 +69,10 @@ namespace {
               // TODO: wrap in ifs
               decl->dropAttr<clang::OptimizeNoneAttr>();
               decl->dropAttr<clang::NoInlineAttr>();
-              decl->addAttr(clang::AlwaysInlineAttr::Create(decl->getASTContext()));
+              // TODO: how to put correct location??
+              clang::SourceLocation location(decl->getSourceRange().getBegin());
+              clang::SourceRange range(location);
+              decl->addAttr(clang::AlwaysInlineAttr::Create(decl->getASTContext(), range));
             }
           }
         }

--- a/clang/labs/lab1/kulagin_aleksandr/alwaysInline.cpp
+++ b/clang/labs/lab1/kulagin_aleksandr/alwaysInline.cpp
@@ -1,52 +1,19 @@
 #include "clang/AST/Decl.h"
-#include "clang/AST/DeclGroup.h"
-#include "clang/AST/Stmt.h"
 #include "clang/AST/AST.h"
 #include "clang/AST/ASTConsumer.h"
+#include "clang/AST/DeclGroup.h"
 #include "clang/AST/RecursiveASTVisitor.h"
+#include "clang/AST/Stmt.h"
 #include "clang/Basic/SourceLocation.h"
 #include "clang/Frontend/CompilerInstance.h"
 #include "clang/Frontend/FrontendPluginRegistry.h"
 #include "llvm/ADT/StringRef.h"
-#include <memory>
 
 
 namespace {
 
   class AlwaysInlineConsumer : public clang::ASTConsumer {
   public:
-    // OLD, do nothing, can safely ignore or delete
-    void HandleTranslationUnitOLD(clang::ASTContext& context) {
-      struct Visitor : public clang::RecursiveASTVisitor<Visitor> {
-        clang::ASTContext& context;
-        Visitor(clang::ASTContext& context) : context(context) {}
-        bool VisitFunctionDecl(clang::FunctionDecl* func) {
-          if (func->getAttr<clang::AlwaysInlineAttr>() != nullptr) {
-            return true;
-          }
-          clang::Stmt* body = func->getBody();
-          bool cond_found = false;
-          if (body != nullptr) {
-            for (clang::Stmt* st : body->children()) {
-              // pls don't use goto
-              // no switch?
-              if (clang::isa<clang::IfStmt>(st) || clang::isa<clang::WhileStmt>(st) || clang::isa<clang::ForStmt>(st)) {
-                cond_found = true;
-                break;
-              }
-            }
-            if (!cond_found) {
-              if (func->hasAttr<clang::NoInlineAttr>()) {
-                func->dropAttr<clang::NoInlineAttr>();
-              }
-              func->addAttr(clang::AlwaysInlineAttr::CreateImplicit(context));
-            }
-          }
-          return true;
-        }
-      } visitor(context);
-      visitor.TraverseDecl(context.getTranslationUnitDecl());
-    }
     bool HandleTopLevelDecl(clang::DeclGroupRef decl_group) override {
       for (clang::Decl* decl : decl_group) {
         if (clang::isa<clang::FunctionDecl>(decl)) {
@@ -57,22 +24,19 @@ namespace {
           if (body != nullptr) {
             bool cond_found = false;
             for (clang::Stmt* st : body->children()) {
-              if (clang::isa<clang::IfStmt>(st) || clang::isa<clang::WhileStmt>(st) || clang::isa<clang::ForStmt>(st)) {
+              if (clang::isa<clang::IfStmt>(st) ||
+              clang::isa<clang::WhileStmt>(st) || clang::isa<clang::ForStmt>(st)
+              || clang::isa<clang::DoStmt>(st)) {
                 cond_found = true;
                 break;
               }
             }
             if (!cond_found) {
-              if (decl->hasAttr<clang::NoInlineAttr>()) {
-                //decl->dropAttr<clang::NoInlineAttr>();
-              }
-              // TODO: wrap in ifs
-              decl->dropAttr<clang::OptimizeNoneAttr>();
-              decl->dropAttr<clang::NoInlineAttr>();
               // TODO: how to put correct location??
               clang::SourceLocation location(decl->getSourceRange().getBegin());
               clang::SourceRange range(location);
-              decl->addAttr(clang::AlwaysInlineAttr::Create(decl->getASTContext(), range));
+              decl->addAttr(
+              clang::AlwaysInlineAttr::Create(decl->getASTContext(), range));
             }
           }
         }
@@ -83,14 +47,20 @@ namespace {
 
   class AlwaysInlinePlugin : public clang::PluginASTAction {
   protected:
-    std::unique_ptr<clang::ASTConsumer> CreateASTConsumer(clang::CompilerInstance& compiler, llvm::StringRef in_file) override {
+    std::unique_ptr<clang::ASTConsumer>
+    CreateASTConsumer(
+    clang::CompilerInstance& compiler, llvm::StringRef in_file
+    ) override {
       return std::make_unique<AlwaysInlineConsumer>();
     }
-    bool ParseArgs(const clang::CompilerInstance& compiler, const std::vector<std::string>& args) override {
+    bool ParseArgs(
+    const clang::CompilerInstance& compiler, const std::vector<std::string>& args
+    ) override {
       return true;
     }
   };
 
 } // namespace
 
-static clang::FrontendPluginRegistry::Add<AlwaysInlinePlugin> X("always-inline", "adds always_inline if no conditions inside function's body");
+static clang::FrontendPluginRegistry::Add<AlwaysInlinePlugin>
+X("always-inline", "adds always_inline if no conditions inside body");

--- a/clang/labs/lab1/kulagin_aleksandr/alwaysInline.cpp
+++ b/clang/labs/lab1/kulagin_aleksandr/alwaysInline.cpp
@@ -1,0 +1,57 @@
+#include "clang/AST/Stmt.h"
+#include "clang/AST/AST.h"
+#include "clang/AST/ASTConsumer.h"
+#include "clang/AST/RecursiveASTVisitor.h"
+#include "clang/Frontend/CompilerInstance.h"
+#include "clang/Frontend/FrontendPluginRegistry.h"
+#include "llvm/ADT/StringRef.h"
+#include <memory>
+
+
+namespace {
+
+  class AlwaysInlineConsumer : public clang::ASTConsumer {
+  public:
+    void HandleTranslationUnit(clang::ASTContext& context) override {
+      struct Visitor : public clang::RecursiveASTVisitor<Visitor> {
+        clang::ASTContext& context;
+        Visitor(clang::ASTContext& context) : context(context) {}
+        bool VisitFunctionDecl(clang::FunctionDecl* func) {
+          if (func->getAttr<clang::AlwaysInlineAttr>() != nullptr) {
+            return true;
+          }
+          clang::Stmt* body = func->getBody();
+          bool cond_found = false;
+          if (body != nullptr) {
+            for (clang::Stmt* st : body->children()) {
+              // pls don't use goto
+              // no switch?
+              if (clang::isa<clang::IfStmt>(st) || clang::isa<clang::WhileStmt>(st) || clang::isa<clang::ForStmt>(st)) {
+                cond_found = true;
+                break;
+              }
+            }
+            if (!cond_found) {
+              func->addAttr(clang::AlwaysInlineAttr::CreateImplicit(context));
+            }
+          }
+          return true;
+        }
+      } visitor(context);
+      visitor.TraverseDecl(context.getTranslationUnitDecl());
+    }
+  };
+
+  class AlwaysInlinePlugin : public clang::PluginASTAction {
+  protected:
+    std::unique_ptr<clang::ASTConsumer> CreateASTConsumer(clang::CompilerInstance& compiler, llvm::StringRef in_file) override {
+      return std::make_unique<AlwaysInlineConsumer>();
+    }
+    bool ParseArgs(const clang::CompilerInstance& compiler, const std::vector<std::string>& args) override {
+      return true;
+    }
+  };
+
+} // namespace
+
+static clang::FrontendPluginRegistry::Add<AlwaysInlinePlugin> X("always-inline", "adds always_inline if no conditions inside function's body");

--- a/clang/labs/lab1/kulagin_aleksandr/alwaysInline.cpp
+++ b/clang/labs/lab1/kulagin_aleksandr/alwaysInline.cpp
@@ -1,6 +1,6 @@
-#include "clang/AST/Decl.h"
 #include "clang/AST/AST.h"
 #include "clang/AST/ASTConsumer.h"
+#include "clang/AST/Decl.h"
 #include "clang/AST/DeclGroup.h"
 #include "clang/AST/RecursiveASTVisitor.h"
 #include "clang/AST/Stmt.h"
@@ -9,66 +9,63 @@
 #include "clang/Frontend/FrontendPluginRegistry.h"
 #include "llvm/ADT/StringRef.h"
 
-
 namespace {
 
-  class AlwaysInlineConsumer : public clang::ASTConsumer {
-  public:
-    bool HandleTopLevelDecl(clang::DeclGroupRef DeclGroup) override {
-      for (clang::Decl *Decl : DeclGroup) {
-        if (clang::isa<clang::FunctionDecl>(Decl)) {
-          if (Decl->getAttr<clang::AlwaysInlineAttr>()) {
-            continue;
+class AlwaysInlineConsumer : public clang::ASTConsumer {
+public:
+  bool HandleTopLevelDecl(clang::DeclGroupRef DeclGroup) override {
+    for (clang::Decl *Decl : DeclGroup) {
+      if (clang::isa<clang::FunctionDecl>(Decl)) {
+        if (Decl->getAttr<clang::AlwaysInlineAttr>()) {
+          continue;
+        }
+        clang::Stmt *Body = Decl->getBody();
+        if (Body != nullptr) {
+          bool CondFound = false;
+          for (clang::Stmt *St : Body->children()) {
+            if (clang::isa<clang::IfStmt>(St) ||
+                clang::isa<clang::WhileStmt>(St) ||
+                clang::isa<clang::ForStmt>(St) ||
+                clang::isa<clang::DoStmt>(St) ||
+                clang::isa<clang::SwitchStmt>(St)) {
+              CondFound = true;
+              break;
+            }
           }
-          clang::Stmt *Body = Decl->getBody();
-          if (Body != nullptr) {
-            bool CondFound = false;
-            for (clang::Stmt *St : Body->children()) {
-              if (clang::isa<clang::IfStmt>(St)
-              || clang::isa<clang::WhileStmt>(St)
-              || clang::isa<clang::ForStmt>(St)
-              || clang::isa<clang::DoStmt>(St)
-              || clang::isa<clang::SwitchStmt>(St)) {
-                CondFound = true;
-                break;
-              }
-            }
-            if (!CondFound) {
-              // TODO: how to put correct location??
-              clang::SourceLocation Location(Decl->getSourceRange().getBegin());
-              clang::SourceRange Range(Location);
-              Decl->addAttr(
-              clang::AlwaysInlineAttr::Create(Decl->getASTContext(), Range));
-            }
+          if (!CondFound) {
+            // TODO: how to put correct location??
+            clang::SourceLocation Location(Decl->getSourceRange().getBegin());
+            clang::SourceRange Range(Location);
+            Decl->addAttr(
+                clang::AlwaysInlineAttr::Create(Decl->getASTContext(), Range));
           }
         }
       }
-      return true;
     }
-  };
+    return true;
+  }
+};
 
-  class AlwaysInlinePlugin : public clang::PluginASTAction {
-  protected:
-    std::unique_ptr<clang::ASTConsumer>
-    CreateASTConsumer(
-    clang::CompilerInstance &Compiler, llvm::StringRef InFile
-    ) override {
-      return std::make_unique<AlwaysInlineConsumer>();
-    }
-    bool ParseArgs(
-    const clang::CompilerInstance &Compiler, const std::vector<std::string> &Args
-    ) override {
-      for (const std::string &Arg : Args) {
-        if (Arg == "--help") {
-          llvm::outs() << "adds always_inline if no conditions inside body\n";
-          return false;
-        }
+class AlwaysInlinePlugin : public clang::PluginASTAction {
+protected:
+  std::unique_ptr<clang::ASTConsumer>
+  CreateASTConsumer(clang::CompilerInstance &Compiler,
+                    llvm::StringRef InFile) override {
+    return std::make_unique<AlwaysInlineConsumer>();
+  }
+  bool ParseArgs(const clang::CompilerInstance &Compiler,
+                 const std::vector<std::string> &Args) override {
+    for (const std::string &Arg : Args) {
+      if (Arg == "--help") {
+        llvm::outs() << "adds always_inline if no conditions inside body\n";
+        return false;
       }
-      return true;
     }
-  };
+    return true;
+  }
+};
 
 } // namespace
 
 static clang::FrontendPluginRegistry::Add<AlwaysInlinePlugin>
-X("always-inline", "adds always_inline if no conditions inside body");
+    X("always-inline", "adds always_inline if no conditions inside body");

--- a/clang/test/lab1/kulagin_aleksandr/test.cpp
+++ b/clang/test/lab1/kulagin_aleksandr/test.cpp
@@ -1,66 +1,71 @@
 // RUN: %clang_cc1 -ast-dump -ast-dump-filter foo -load %llvmshlibdir/kulaginAlwaysInline%pluginext -add-plugin always-inline %s | FileCheck %s
 // COM: %clang_cc1 -load %llvmshlibdir/kulaginAlwaysInline%pluginext -add-plugin always-inline %s -emit-llvm -o - | FileCheck %s
 
-// CHECK: FunctionDecl {{0[xX][0-9a-fA-F]+ <.+test\.cpp:[0-9]+:[0-9]+, line:[0-9]+:[0-9]+> line:[0-9]+:[0-9]+ foo1 'void \(\)'}}
-void __attribute__((always_inline)) foo1() {
-  return;
+// CHECK: FunctionDecl {{0[xX][0-9a-fA-F]+ <.+test\.cpp:[0-9]+:[0-9]+, line:[0-9]+:[0-9]+> line:[0-9]+:[0-9]+ foo1 'int \(\)'}}
+int __attribute__((always_inline)) foo1() {
+  return 0;
 }
 // CHECK: `-AlwaysInlineAttr {{0[xX][0-9a-fA-F]+ <line:[0-9]+:[0-9]+> always_inline}}
 
-// CHECK: FunctionDecl {{0[xX][0-9a-fA-F]+ <.+test\.cpp:[0-9]+:[0-9]+, line:[0-9]+:[0-9]+> line:[0-9]+:[0-9]+ foo2 'void \(\)'}}
-void foo2() {
-
+// CHECK: FunctionDecl {{0[xX][0-9a-fA-F]+ <.+test\.cpp:[0-9]+:[0-9]+, line:[0-9]+:[0-9]+> line:[0-9]+:[0-9]+ foo2 'int \(\)'}}
+int foo2() {
+  return 0;
 }
 // CHECK: `-AlwaysInlineAttr {{0[xX][0-9a-fA-F]+ <line:[0-9]+:[0-9]+> always_inline}}
 
-// CHECK: FunctionDecl {{0[xX][0-9a-fA-F]+ <.+test\.cpp:[0-9]+:[0-9]+, line:[0-9]+:[0-9]+> line:[0-9]+:[0-9]+ foo3 'void \(\)'}}
-void foo3() {
+// CHECK: FunctionDecl {{0[xX][0-9a-fA-F]+ <.+test\.cpp:[0-9]+:[0-9]+, line:[0-9]+:[0-9]+> line:[0-9]+:[0-9]+ foo3 'int \(\)'}}
+int foo3() {
   bool f = true;
   if (f) {
     f = false;
   }
+  return 0;
 }
 // CHECK-NOT: `-AlwaysInlineAttr {{0[xX][0-9a-fA-F]+ <line:[0-9]+:[0-9]+> always_inline}}
 
-// CHECK: FunctionDecl {{0[xX][0-9a-fA-F]+ <.+test\.cpp:[0-9]+:[0-9]+, line:[0-9]+:[0-9]+> line:[0-9]+:[0-9]+ foo4 'void \(\)'}}
-void foo4() {
+// CHECK: FunctionDecl {{0[xX][0-9a-fA-F]+ <.+test\.cpp:[0-9]+:[0-9]+, line:[0-9]+:[0-9]+> line:[0-9]+:[0-9]+ foo4 'int \(\)'}}
+int foo4() {
   while (true) {
 
   }
+  return 0;
 }
 // CHECK-NOT: `-AlwaysInlineAttr {{0[xX][0-9a-fA-F]+ <line:[0-9]+:[0-9]+> always_inline}}
 
-// CHECK: FunctionDecl {{0[xX][0-9a-fA-F]+ <.+test\.cpp:[0-9]+:[0-9]+, line:[0-9]+:[0-9]+> line:[0-9]+:[0-9]+ foo5 'void \(\)'}}
-void foo5() {
+// CHECK: FunctionDecl {{0[xX][0-9a-fA-F]+ <.+test\.cpp:[0-9]+:[0-9]+, line:[0-9]+:[0-9]+> line:[0-9]+:[0-9]+ foo5 'int \(\)'}}
+int foo5() {
   for (int i = 0; i < 5; i++) {
 
   }
+  return 0;
 }
 // CHECK-NOT: `-AlwaysInlineAttr {{0[xX][0-9a-fA-F]+ <line:[0-9]+:[0-9]+> always_inline}}
 
-// CHECK: FunctionDecl {{0[xX][0-9a-fA-F]+ <.+test\.cpp:[0-9]+:[0-9]+, line:[0-9]+:[0-9]+> line:[0-9]+:[0-9]+ foo6 'void \(\)'}}
-void foo6() {
+// CHECK: FunctionDecl {{0[xX][0-9a-fA-F]+ <.+test\.cpp:[0-9]+:[0-9]+, line:[0-9]+:[0-9]+> line:[0-9]+:[0-9]+ foo6 'int \(\)'}}
+int foo6() {
   while (true) {
     if (false) {
       int d = -1;
       if (d) {
-        return;
+        return d;
       }
     }
   }
+  return 0;
 }
 // CHECK-NOT: `-AlwaysInlineAttr {{0[xX][0-9a-fA-F]+ <line:[0-9]+:[0-9]+> always_inline}}
 
-// CHECK: FunctionDecl {{0[xX][0-9a-fA-F]+ <.+test\.cpp:[0-9]+:[0-9]+, line:[0-9]+:[0-9]+> line:[0-9]+:[0-9]+ foo7 'void \(\)'}}
-void foo7() {
+// CHECK: FunctionDecl {{0[xX][0-9a-fA-F]+ <.+test\.cpp:[0-9]+:[0-9]+, line:[0-9]+:[0-9]+> line:[0-9]+:[0-9]+ foo7 'int \(\)'}}
+int foo7() {
   do {
 
   } while(true);
+  return 0;
 }
 // CHECK-NOT: `-AlwaysInlineAttr {{0[xX][0-9a-fA-F]+ <line:[0-9]+:[0-9]+> always_inline}}
 
-// CHECK: FunctionDecl {{0[xX][0-9a-fA-F]+ <.+test\.cpp:[0-9]+:[0-9]+, line:[0-9]+:[0-9]+> line:[0-9]+:[0-9]+ foo8 'void \(\)'}}
-void foo8() {
+// CHECK: FunctionDecl {{0[xX][0-9a-fA-F]+ <.+test\.cpp:[0-9]+:[0-9]+, line:[0-9]+:[0-9]+> line:[0-9]+:[0-9]+ foo8 'int \(\)'}}
+int foo8() {
   int a = 1;
   switch (a) {
     case 1:
@@ -68,6 +73,7 @@ void foo8() {
     default:
       break;
   }
+  return a;
 }
 // CHECK-NOT: `-AlwaysInlineAttr {{0[xX][0-9a-fA-F]+ <line:[0-9]+:[0-9]+> always_inline}}
 

--- a/clang/test/lab1/kulagin_aleksandr/test.cpp
+++ b/clang/test/lab1/kulagin_aleksandr/test.cpp
@@ -1,19 +1,15 @@
 // RUN: %clang_cc1 -ast-dump -ast-dump-filter foo -load %llvmshlibdir/kulaginAlwaysInline%pluginext -add-plugin always-inline %s | FileCheck %s
 // COM: %clang_cc1 -load %llvmshlibdir/kulaginAlwaysInline%pluginext -add-plugin always-inline %s -emit-llvm -o - | FileCheck %s
 
-// CHECK: FunctionDecl {{0[xX][0-9a-fA-F]+ <.+test\.cpp:[0-9]+:[0-9]+, line:[0-9]+:[0-9]+> line:[0-9]+:[0-9]+ foo1 'int \(\)'}}
-int __attribute__((always_inline)) foo1() {
-  return 0;
-}
-// CHECK: `-AlwaysInlineAttr {{0[xX][0-9a-fA-F]+ <line:[0-9]+:[0-9]+> always_inline}}
+// CHECK: FunctionDecl {{0[xX][0-9a-fA-F]+ <.+test\.cpp:([0-9]+:[0-9]|[0-9]+), (line|col):([0-9]+:[0-9]|[0-9]+)> (line|col):([0-9]+:[0-9]|[0-9]+) foo1 'int \(\)'}}
+int __attribute__((always_inline)) foo1() { return 0; }
+// CHECK: `-AlwaysInlineAttr {{0[xX][0-9a-fA-F]+ <(line|col):([0-9]+:[0-9]|[0-9]+)> always_inline}}
 
-// CHECK: FunctionDecl {{0[xX][0-9a-fA-F]+ <.+test\.cpp:[0-9]+:[0-9]+, line:[0-9]+:[0-9]+> line:[0-9]+:[0-9]+ foo2 'int \(\)'}}
-int foo2() {
-  return 0;
-}
-// CHECK: `-AlwaysInlineAttr {{0[xX][0-9a-fA-F]+ <line:[0-9]+:[0-9]+> always_inline}}
+// CHECK: FunctionDecl {{0[xX][0-9a-fA-F]+ <.+test\.cpp:([0-9]+:[0-9]|[0-9]+), (line|col):([0-9]+:[0-9]|[0-9]+)> (line|col):([0-9]+:[0-9]|[0-9]+) foo2 'int \(\)'}}
+int foo2() { return 0; }
+// CHECK: `-AlwaysInlineAttr {{0[xX][0-9a-fA-F]+ <(line|col):([0-9]+:[0-9]|[0-9]+)> always_inline}}
 
-// CHECK: FunctionDecl {{0[xX][0-9a-fA-F]+ <.+test\.cpp:[0-9]+:[0-9]+, line:[0-9]+:[0-9]+> line:[0-9]+:[0-9]+ foo3 'int \(\)'}}
+// CHECK: FunctionDecl {{0[xX][0-9a-fA-F]+ <.+test\.cpp:([0-9]+:[0-9]|[0-9]+), (line|col):([0-9]+:[0-9]|[0-9]+)> (line|col):([0-9]+:[0-9]|[0-9]+) foo3 'int \(\)'}}
 int foo3() {
   bool f = true;
   if (f) {
@@ -21,27 +17,25 @@ int foo3() {
   }
   return 0;
 }
-// CHECK-NOT: `-AlwaysInlineAttr {{0[xX][0-9a-fA-F]+ <line:[0-9]+:[0-9]+> always_inline}}
+// CHECK-NOT: `-AlwaysInlineAttr {{0[xX][0-9a-fA-F]+ <(line|col):([0-9]+:[0-9]|[0-9]+)> always_inline}}
 
-// CHECK: FunctionDecl {{0[xX][0-9a-fA-F]+ <.+test\.cpp:[0-9]+:[0-9]+, line:[0-9]+:[0-9]+> line:[0-9]+:[0-9]+ foo4 'int \(\)'}}
+// CHECK: FunctionDecl {{0[xX][0-9a-fA-F]+ <.+test\.cpp:([0-9]+:[0-9]|[0-9]+), (line|col):([0-9]+:[0-9]|[0-9]+)> (line|col):([0-9]+:[0-9]|[0-9]+) foo4 'int \(\)'}}
 int foo4() {
   while (true) {
-
   }
   return 0;
 }
-// CHECK-NOT: `-AlwaysInlineAttr {{0[xX][0-9a-fA-F]+ <line:[0-9]+:[0-9]+> always_inline}}
+// CHECK-NOT: `-AlwaysInlineAttr {{0[xX][0-9a-fA-F]+ <(line|col):([0-9]+:[0-9]|[0-9]+)> always_inline}}
 
-// CHECK: FunctionDecl {{0[xX][0-9a-fA-F]+ <.+test\.cpp:[0-9]+:[0-9]+, line:[0-9]+:[0-9]+> line:[0-9]+:[0-9]+ foo5 'int \(\)'}}
+// CHECK: FunctionDecl {{0[xX][0-9a-fA-F]+ <.+test\.cpp:([0-9]+:[0-9]|[0-9]+), (line|col):([0-9]+:[0-9]|[0-9]+)> (line|col):([0-9]+:[0-9]|[0-9]+) foo5 'int \(\)'}}
 int foo5() {
   for (int i = 0; i < 5; i++) {
-
   }
   return 0;
 }
-// CHECK-NOT: `-AlwaysInlineAttr {{0[xX][0-9a-fA-F]+ <line:[0-9]+:[0-9]+> always_inline}}
+// CHECK-NOT: `-AlwaysInlineAttr {{0[xX][0-9a-fA-F]+ <(line|col):([0-9]+:[0-9]|[0-9]+)> always_inline}}
 
-// CHECK: FunctionDecl {{0[xX][0-9a-fA-F]+ <.+test\.cpp:[0-9]+:[0-9]+, line:[0-9]+:[0-9]+> line:[0-9]+:[0-9]+ foo6 'int \(\)'}}
+// CHECK: FunctionDecl {{0[xX][0-9a-fA-F]+ <.+test\.cpp:([0-9]+:[0-9]|[0-9]+), (line|col):([0-9]+:[0-9]|[0-9]+)> (line|col):([0-9]+:[0-9]|[0-9]+) foo6 'int \(\)'}}
 int foo6() {
   while (true) {
     if (false) {
@@ -53,34 +47,34 @@ int foo6() {
   }
   return 0;
 }
-// CHECK-NOT: `-AlwaysInlineAttr {{0[xX][0-9a-fA-F]+ <line:[0-9]+:[0-9]+> always_inline}}
+// CHECK-NOT: `-AlwaysInlineAttr {{0[xX][0-9a-fA-F]+ <(line|col):([0-9]+:[0-9]|[0-9]+)> always_inline}}
 
-// CHECK: FunctionDecl {{0[xX][0-9a-fA-F]+ <.+test\.cpp:[0-9]+:[0-9]+, line:[0-9]+:[0-9]+> line:[0-9]+:[0-9]+ foo7 'int \(\)'}}
+// CHECK: FunctionDecl {{0[xX][0-9a-fA-F]+ <.+test\.cpp:([0-9]+:[0-9]|[0-9]+), (line|col):([0-9]+:[0-9]|[0-9]+)> (line|col):([0-9]+:[0-9]|[0-9]+) foo7 'int \(\)'}}
 int foo7() {
   do {
 
-  } while(true);
+  } while (true);
   return 0;
 }
-// CHECK-NOT: `-AlwaysInlineAttr {{0[xX][0-9a-fA-F]+ <line:[0-9]+:[0-9]+> always_inline}}
+// CHECK-NOT: `-AlwaysInlineAttr {{0[xX][0-9a-fA-F]+ <(line|col):([0-9]+:[0-9]|[0-9]+)> always_inline}}
 
-// CHECK: FunctionDecl {{0[xX][0-9a-fA-F]+ <.+test\.cpp:[0-9]+:[0-9]+, line:[0-9]+:[0-9]+> line:[0-9]+:[0-9]+ foo8 'int \(\)'}}
+// CHECK: FunctionDecl {{0[xX][0-9a-fA-F]+ <.+test\.cpp:([0-9]+:[0-9]|[0-9]+), (line|col):([0-9]+:[0-9]|[0-9]+)> (line|col):([0-9]+:[0-9]|[0-9]+) foo8 'int \(\)'}}
 int foo8() {
   int a = 1;
   switch (a) {
-    case 1:
-      break;
-    default:
-      break;
+  case 1:
+    break;
+  default:
+    break;
   }
   return a;
 }
-// CHECK-NOT: `-AlwaysInlineAttr {{0[xX][0-9a-fA-F]+ <line:[0-9]+:[0-9]+> always_inline}}
+// CHECK-NOT: `-AlwaysInlineAttr {{0[xX][0-9a-fA-F]+ <(line|col):([0-9]+:[0-9]|[0-9]+)> always_inline}}
 
-// CHECK: FunctionDecl {{0[xX][0-9a-fA-F]+ <.+test\.cpp:[0-9]+:[0-9]+, line:[0-9]+:[0-9]+> line:[0-9]+:[0-9]+ foo9 'int \(int, int\)'}}
+// CHECK: FunctionDecl {{0[xX][0-9a-fA-F]+ <.+test\.cpp:([0-9]+:[0-9]|[0-9]+), (line|col):([0-9]+:[0-9]|[0-9]+)> (line|col):([0-9]+:[0-9]|[0-9]+) foo9 'int \(int, int\)'}}
 int foo9(int a, int b) {
   int c;
-  c = a+b;
+  c = a + b;
   return c;
 }
-// CHECK: `-AlwaysInlineAttr {{0[xX][0-9a-fA-F]+ <line:[0-9]+:[0-9]+> always_inline}}
+// CHECK: `-AlwaysInlineAttr {{0[xX][0-9a-fA-F]+ <(line|col):([0-9]+:[0-9]|[0-9]+)> always_inline}}

--- a/clang/test/lab1/kulagin_aleksandr/test.cpp
+++ b/clang/test/lab1/kulagin_aleksandr/test.cpp
@@ -1,25 +1,28 @@
 // RUN: %clang_cc1 -ast-dump -ast-dump-filter foo -load %llvmshlibdir/kulaginAlwaysInline%pluginext -add-plugin always-inline %s | FileCheck %s
-// COM: RUN: %clang_cc1 -load %llvmshlibdir/kulaginAlwaysInline%pluginext -add-plugin always-inline %s -emit-llvm -o - | FileCheck %s
+// COM: %clang_cc1 -load %llvmshlibdir/kulaginAlwaysInline%pluginext -add-plugin always-inline %s -emit-llvm -o - | FileCheck %s
 
 // CHECK: FunctionDecl {{0[xX][0-9a-fA-F]+ <.+test\.cpp:[0-9]+:[0-9]+, line:[0-9]+:[0-9]+> line:[0-9]+:[0-9]+ foo1 'void \(\)'}}
 void __attribute__((always_inline)) foo1() {
   return;
 }
-// CHECK: `-AlwaysInlineAttr 0[xX][0-9a-fA-F]+ <line:[0-9]+:[0-9]+> always_inline
+// CHECK: `-AlwaysInlineAttr {{0[xX][0-9a-fA-F]+ <line:[0-9]+:[0-9]+> always_inline}}
 
 // CHECK: FunctionDecl {{0[xX][0-9a-fA-F]+ <.+test\.cpp:[0-9]+:[0-9]+, line:[0-9]+:[0-9]+> line:[0-9]+:[0-9]+ foo2 'void \(\)'}}
 void foo2() {
 
 }
-// CHECK: `-AlwaysInlineAttr 0[xX][0-9a-fA-F]+ <line:[0-9]+:[0-9]+> always_inline
+// CHECK: `-AlwaysInlineAttr {{0[xX][0-9a-fA-F]+ <line:[0-9]+:[0-9]+> always_inline}}
 
-// COM: test the rest after foo2 is resolved
-
+// CHECK: FunctionDecl {{0[xX][0-9a-fA-F]+ <.+test\.cpp:[0-9]+:[0-9]+, line:[0-9]+:[0-9]+> line:[0-9]+:[0-9]+ foo3 'void \(\)'}}
 void foo3() {
   if (true) {
-
+    int c;
   }
 }
+// CHECK-NOT: `-AlwaysInlineAttr {{0[xX][0-9a-fA-F]+ <line:[0-9]+:[0-9]+> always_inline}}
+
+// CHECK: FunctionDecl {{0[xX][0-9a-fA-F]+ <.+test\.cpp:[0-9]+:[0-9]+, line:[0-9]+:[0-9]+> line:[0-9]+:[0-9]+ foo4 'void \(\)'}}
+// COM: test the rest after -emit-llvm is resolved
 
 void foo4() {
   while (true) {

--- a/clang/test/lab1/kulagin_aleksandr/test.cpp
+++ b/clang/test/lab1/kulagin_aleksandr/test.cpp
@@ -1,0 +1,51 @@
+// RUN: %clang_cc1 -ast-dump -ast-dump-filter foo -load %llvmshlibdir/kulaginAlwaysInline%pluginext -add-plugin always-inline %s | FileCheck %s
+// COM: RUN: %clang_cc1 -load %llvmshlibdir/kulaginAlwaysInline%pluginext -add-plugin always-inline %s -emit-llvm -o - | FileCheck %s
+
+// CHECK: FunctionDecl {{0[xX][0-9a-fA-F]+ <.+test\.cpp:[0-9]+:[0-9]+, line:[0-9]+:[0-9]+> line:[0-9]+:[0-9]+ foo1 'void \(\)'}}
+void __attribute__((always_inline)) foo1() {
+  return;
+}
+// CHECK: `-AlwaysInlineAttr 0[xX][0-9a-fA-F]+ <line:[0-9]+:[0-9]+> always_inline
+
+// CHECK: FunctionDecl {{0[xX][0-9a-fA-F]+ <.+test\.cpp:[0-9]+:[0-9]+, line:[0-9]+:[0-9]+> line:[0-9]+:[0-9]+ foo2 'void \(\)'}}
+void foo2() {
+
+}
+// CHECK: `-AlwaysInlineAttr 0[xX][0-9a-fA-F]+ <line:[0-9]+:[0-9]+> always_inline
+
+// COM: test the rest after foo2 is resolved
+
+void foo3() {
+  if (true) {
+
+  }
+}
+
+void foo4() {
+  while (true) {
+
+  }
+}
+
+void foo5() {
+  for (int i = 0; i < 5; i++) {
+
+  }
+}
+
+void foo6() {
+  while (true) {
+    if (false) {
+      int d = -1;
+      if (d) {
+        return;
+      }
+    }
+  }
+}
+
+int foo7(int a, int b) {
+  int c;
+  c = a+b;
+  return c;
+}

--- a/clang/test/lab1/kulagin_aleksandr/test.cpp
+++ b/clang/test/lab1/kulagin_aleksandr/test.cpp
@@ -59,8 +59,20 @@ void foo7() {
 }
 // CHECK-NOT: `-AlwaysInlineAttr {{0[xX][0-9a-fA-F]+ <line:[0-9]+:[0-9]+> always_inline}}
 
-// CHECK: FunctionDecl {{0[xX][0-9a-fA-F]+ <.+test\.cpp:[0-9]+:[0-9]+, line:[0-9]+:[0-9]+> line:[0-9]+:[0-9]+ foo8 'int \(int, int\)'}}
-int foo8(int a, int b) {
+// CHECK: FunctionDecl {{0[xX][0-9a-fA-F]+ <.+test\.cpp:[0-9]+:[0-9]+, line:[0-9]+:[0-9]+> line:[0-9]+:[0-9]+ foo8 'void \(\)'}}
+void foo8() {
+  int a = 1;
+  switch (a) {
+    case 1:
+      break;
+    default:
+      break;
+  }
+}
+// CHECK-NOT: `-AlwaysInlineAttr {{0[xX][0-9a-fA-F]+ <line:[0-9]+:[0-9]+> always_inline}}
+
+// CHECK: FunctionDecl {{0[xX][0-9a-fA-F]+ <.+test\.cpp:[0-9]+:[0-9]+, line:[0-9]+:[0-9]+> line:[0-9]+:[0-9]+ foo9 'int \(int, int\)'}}
+int foo9(int a, int b) {
   int c;
   c = a+b;
   return c;

--- a/clang/test/lab1/kulagin_aleksandr/test.cpp
+++ b/clang/test/lab1/kulagin_aleksandr/test.cpp
@@ -15,27 +15,30 @@ void foo2() {
 
 // CHECK: FunctionDecl {{0[xX][0-9a-fA-F]+ <.+test\.cpp:[0-9]+:[0-9]+, line:[0-9]+:[0-9]+> line:[0-9]+:[0-9]+ foo3 'void \(\)'}}
 void foo3() {
-  if (true) {
-    int c;
+  bool f = true;
+  if (f) {
+    f = false;
   }
 }
 // CHECK-NOT: `-AlwaysInlineAttr {{0[xX][0-9a-fA-F]+ <line:[0-9]+:[0-9]+> always_inline}}
 
 // CHECK: FunctionDecl {{0[xX][0-9a-fA-F]+ <.+test\.cpp:[0-9]+:[0-9]+, line:[0-9]+:[0-9]+> line:[0-9]+:[0-9]+ foo4 'void \(\)'}}
-// COM: test the rest after -emit-llvm is resolved
-
 void foo4() {
   while (true) {
 
   }
 }
+// CHECK-NOT: `-AlwaysInlineAttr {{0[xX][0-9a-fA-F]+ <line:[0-9]+:[0-9]+> always_inline}}
 
+// CHECK: FunctionDecl {{0[xX][0-9a-fA-F]+ <.+test\.cpp:[0-9]+:[0-9]+, line:[0-9]+:[0-9]+> line:[0-9]+:[0-9]+ foo5 'void \(\)'}}
 void foo5() {
   for (int i = 0; i < 5; i++) {
 
   }
 }
+// CHECK-NOT: `-AlwaysInlineAttr {{0[xX][0-9a-fA-F]+ <line:[0-9]+:[0-9]+> always_inline}}
 
+// CHECK: FunctionDecl {{0[xX][0-9a-fA-F]+ <.+test\.cpp:[0-9]+:[0-9]+, line:[0-9]+:[0-9]+> line:[0-9]+:[0-9]+ foo6 'void \(\)'}}
 void foo6() {
   while (true) {
     if (false) {
@@ -46,9 +49,20 @@ void foo6() {
     }
   }
 }
+// CHECK-NOT: `-AlwaysInlineAttr {{0[xX][0-9a-fA-F]+ <line:[0-9]+:[0-9]+> always_inline}}
 
-int foo7(int a, int b) {
+// CHECK: FunctionDecl {{0[xX][0-9a-fA-F]+ <.+test\.cpp:[0-9]+:[0-9]+, line:[0-9]+:[0-9]+> line:[0-9]+:[0-9]+ foo7 'void \(\)'}}
+void foo7() {
+  do {
+
+  } while(true);
+}
+// CHECK-NOT: `-AlwaysInlineAttr {{0[xX][0-9a-fA-F]+ <line:[0-9]+:[0-9]+> always_inline}}
+
+// CHECK: FunctionDecl {{0[xX][0-9a-fA-F]+ <.+test\.cpp:[0-9]+:[0-9]+, line:[0-9]+:[0-9]+> line:[0-9]+:[0-9]+ foo8 'int \(int, int\)'}}
+int foo8(int a, int b) {
   int c;
   c = a+b;
   return c;
 }
+// CHECK: `-AlwaysInlineAttr {{0[xX][0-9a-fA-F]+ <line:[0-9]+:[0-9]+> always_inline}}


### PR DESCRIPTION
Silently adds always_inline attribute to a function without conditions inside it's body (no if, for, while, do while, switch statements).
Issues:
1. Ignores goto statements
2. While -ast-dump recognizes new attribute, -emit-llvm does not for whatever reason.
3. Position for always_inline attribute is incorrect and I don't know how to fix it. It will always show <line:[function line]:1>.