### PR TITLE
Kulagin Aleksandr / lab 4 / var 2

### DIFF
--- a/mlir/lib/Transforms/lab4/kulagin_aleksandr/CMakeLists.txt
+++ b/mlir/lib/Transforms/lab4/kulagin_aleksandr/CMakeLists.txt
@@ -1,0 +1,12 @@
+set(PluginName KulaginAleksandrFMAPass)
+
+file(GLOB_RECURSE ALL_SOURCE_FILES *.cpp *.h)
+add_llvm_pass_plugin(${PluginName}
+        ${ALL_SOURCE_FILES}
+        DEPENDS
+        intrinsics_gen
+        MLIRBuiltinLocationAttributesIncGen
+        BUILDTREE_ONLY
+        )
+
+set(MLIR_TEST_DEPENDS ${PluginName} ${MLIR_TEST_DEPENDS} PARENT_SCOPE)

--- a/mlir/lib/Transforms/lab4/kulagin_aleksandr/KulaginAleksandrFMAPass.cpp
+++ b/mlir/lib/Transforms/lab4/kulagin_aleksandr/KulaginAleksandrFMAPass.cpp
@@ -22,28 +22,23 @@ public:
   void runOnOperation() override {
     mlir::ModuleOp module = getOperation();
     module.walk([this](mlir::Operation *op) {
-      if (mlir::LLVM::FAddOp addOp = mlir::dyn_cast<mlir::LLVM::FAddOp>(op)) {
+      if (auto addOp = mlir::dyn_cast<mlir::LLVM::FAddOp>(op)) {
         mlir::Value lhv = addOp.getOperand(0);
         mlir::Value rhv = addOp.getOperand(1);
-        if (mlir::LLVM::FMulOp defOpLH =
-                lhv.getDefiningOp<mlir::LLVM::FMulOp>()) {
+        if (auto defOpLH = lhv.getDefiningOp<mlir::LLVM::FMulOp>()) {
           buildFMAOp(addOp, defOpLH, defOpLH.getOperand(0),
                      defOpLH.getOperand(1), rhv);
-        } else if (mlir::LLVM::FMulOp defOpRH =
-                       rhv.getDefiningOp<mlir::LLVM::FMulOp>()) {
+        } else if (auto defOpRH = rhv.getDefiningOp<mlir::LLVM::FMulOp>()) {
           buildFMAOp(addOp, defOpRH, defOpRH.getOperand(0),
                      defOpRH.getOperand(1), lhv);
         }
-      } else if (mlir::LLVM::FSubOp subOp =
-                     mlir::dyn_cast<mlir::LLVM::FSubOp>(op)) {
+      } else if (auto subOp = mlir::dyn_cast<mlir::LLVM::FSubOp>(op)) {
         mlir::Value lhv = subOp.getOperand(0);
         mlir::Value rhv = subOp.getOperand(1);
-        if (mlir::LLVM::FMulOp defOpLH =
-                lhv.getDefiningOp<mlir::LLVM::FMulOp>()) {
+        if (auto defOpLH = lhv.getDefiningOp<mlir::LLVM::FMulOp>()) {
           buildFMAOp(subOp, defOpLH, defOpLH.getOperand(0),
                      defOpLH.getOperand(1), buildFNegativeOp(subOp, rhv));
-        } else if (mlir::LLVM::FMulOp defOpRH =
-                       rhv.getDefiningOp<mlir::LLVM::FMulOp>()) {
+        } else if (auto defOpRH = rhv.getDefiningOp<mlir::LLVM::FMulOp>()) {
           buildFMAOp(subOp, defOpRH,
                      buildFNegativeOp(subOp, defOpRH.getOperand(0)),
                      defOpRH.getOperand(1), lhv);

--- a/mlir/lib/Transforms/lab4/kulagin_aleksandr/KulaginAleksandrFMAPass.cpp
+++ b/mlir/lib/Transforms/lab4/kulagin_aleksandr/KulaginAleksandrFMAPass.cpp
@@ -1,0 +1,91 @@
+#include "mlir/Dialect/LLVMIR/LLVMDialect.h"
+#include "mlir/IR/Builders.h"
+#include "mlir/IR/Operation.h"
+#include "mlir/IR/PatternMatch.h"
+#include "mlir/Pass/Pass.h"
+#include "mlir/Pass/PassRegistry.h"
+#include "mlir/Support/TypeID.h"
+#include "mlir/Tools/Plugins/PassPlugin.h"
+
+namespace {
+class KulaginAleksandrFMAPass
+    : public mlir::PassWrapper<KulaginAleksandrFMAPass,
+                               mlir::OperationPass<mlir::ModuleOp>> {
+public:
+  static const char *pluginName;
+  static const char *pluginVersion;
+  mlir::StringRef getArgument() const final { return pluginName; }
+  mlir::StringRef getDescription() const final {
+    return "A pass that merges multiplication and addition into a single "
+           "math.fma";
+  }
+  void runOnOperation() override {
+    mlir::ModuleOp module = getOperation();
+    module.walk([this](mlir::Operation *op) {
+      if (mlir::LLVM::FAddOp addOp = mlir::dyn_cast<mlir::LLVM::FAddOp>(op)) {
+        mlir::Value lhv = addOp.getOperand(0);
+        mlir::Value rhv = addOp.getOperand(1);
+        if (mlir::LLVM::FMulOp defOpLH =
+                lhv.getDefiningOp<mlir::LLVM::FMulOp>()) {
+          buildFMAOp(addOp, defOpLH, defOpLH.getOperand(0),
+                     defOpLH.getOperand(1), rhv);
+        } else if (mlir::LLVM::FMulOp defOpRH =
+                       rhv.getDefiningOp<mlir::LLVM::FMulOp>()) {
+          buildFMAOp(addOp, defOpRH, defOpRH.getOperand(0),
+                     defOpRH.getOperand(1), lhv);
+        }
+      } else if (mlir::LLVM::FSubOp subOp =
+                     mlir::dyn_cast<mlir::LLVM::FSubOp>(op)) {
+        mlir::Value lhv = subOp.getOperand(0);
+        mlir::Value rhv = subOp.getOperand(1);
+        if (mlir::LLVM::FMulOp defOpLH =
+                lhv.getDefiningOp<mlir::LLVM::FMulOp>()) {
+          buildFMAOp(subOp, defOpLH, defOpLH.getOperand(0),
+                     defOpLH.getOperand(1), buildFNegativeOp(subOp, rhv));
+        } else if (mlir::LLVM::FMulOp defOpRH =
+                       rhv.getDefiningOp<mlir::LLVM::FMulOp>()) {
+          buildFMAOp(subOp, defOpRH,
+                     buildFNegativeOp(subOp, defOpRH.getOperand(0)),
+                     defOpRH.getOperand(1), lhv);
+        }
+      }
+    });
+  }
+
+protected:
+  mlir::Value buildFNegativeOp(mlir::LLVM::FSubOp &op, const mlir::Value &v) {
+    mlir::OpBuilder builder(op);
+    return builder.create<mlir::LLVM::FNegOp>(op.getLoc(), v);
+  }
+
+  template <typename T>
+  void buildFMAOp(T &op, mlir::LLVM::FMulOp defMul, mlir::Value defMulOperand1,
+                  mlir::Value defMulOperand2, const mlir::Value &otherOperand) {
+    mlir::OpBuilder builder(op);
+    mlir::Value fma = builder.create<mlir::LLVM::FMAOp>(
+        op.getLoc(), defMulOperand1, defMulOperand2, otherOperand);
+    op.replaceAllUsesWith(fma);
+    op.erase();
+    if (defMul.getResult().use_empty()) {
+      defMul.erase();
+    }
+  }
+};
+} // namespace
+
+const char *KulaginAleksandrFMAPass::pluginName = "KulaginAleksandrFMA";
+const char *KulaginAleksandrFMAPass::pluginVersion = "1.0.0";
+
+MLIR_DECLARE_EXPLICIT_TYPE_ID(KulaginAleksandrFMAPass);
+MLIR_DEFINE_EXPLICIT_TYPE_ID(KulaginAleksandrFMAPass);
+
+mlir::PassPluginLibraryInfo getKulaginAleksandrFMAPassPluginInfo() {
+  return {MLIR_PLUGIN_API_VERSION, KulaginAleksandrFMAPass::pluginName,
+          KulaginAleksandrFMAPass::pluginVersion,
+          []() { mlir::PassRegistration<KulaginAleksandrFMAPass>(); }};
+}
+
+extern "C" LLVM_ATTRIBUTE_WEAK mlir::PassPluginLibraryInfo
+mlirGetPassPluginInfo() {
+  return getKulaginAleksandrFMAPassPluginInfo();
+}

--- a/mlir/test/Transforms/lab4/kulagin_aleksandr/test.mlir
+++ b/mlir/test/Transforms/lab4/kulagin_aleksandr/test.mlir
@@ -1,0 +1,157 @@
+// RUN: mlir-opt -load-pass-plugin=%mlir_lib_dir/KulaginAleksandrFMAPass%shlibext --pass-pipeline="builtin.module(KulaginAleksandrFMA)" %s | FileCheck %s
+
+//------------C
+
+//double f1(double a, double b, double c) {
+//  double d = a + b * c;
+//  return d;
+//}
+//
+//double f2(double a, double b, double c) {
+//  double d = a - b * c;
+//  return d;
+//}
+//
+//double f3(double a, double b, double c) {
+//  double d = b * c - a;
+//  return d;
+//}
+//
+//double f4(double a, double b, double c) {
+//  double d = a + b / c;
+//  return d;
+//}
+//
+//double f5(double a, double b, double c) {
+//  double d = a + b + c;
+//  return d;
+//}
+//
+//double f6(double a, double b, double c) {
+//  double e = a * b;
+//  double d = e + c;
+//  double f = d / e + 1;
+//  return f;
+//}
+
+//------------llvm ir
+
+//define dso_local double @_Z2f1ddd(double %0, double %1, double %2) local_unnamed_addr {
+//  %4 = fmul double %1, %2
+//  %5 = fadd double %4, %0
+//  ret double %5
+//}
+//
+//define dso_local double @_Z2f2ddd(double %0, double %1, double %2) local_unnamed_addr {
+//  %4 = fmul double %1, %2
+//  %5 = fsub double %0, %4
+//  ret double %5
+//}
+//
+//define dso_local double @_Z2f3ddd(double %0, double %1, double %2) local_unnamed_addr {
+//  %4 = fmul double %1, %2
+//  %5 = fsub double %4, %0
+//  ret double %5
+//}
+//
+//define dso_local double @_Z2f4ddd(double %0, double %1, double %2) local_unnamed_addr {
+//  %4 = fdiv double %1, %2
+//  %5 = fadd double %4, %0
+//  ret double %5
+//}
+//
+//define dso_local double @_Z2f5ddd(double %0, double %1, double %2) local_unnamed_addr {
+//  %4 = fadd double %0, %1
+//  %5 = fadd double %4, %2
+//  ret double %5
+//}
+//
+//define dso_local double @_Z2f6ddd(double %0, double %1, double %2) local_unnamed_addr {
+//  %4 = fmul double %0, %1
+//  %5 = fadd double %4, %2
+//  %6 = fdiv double %4, %5
+//  %7 = fadd double %6, 1.000000e+00
+//  ret double %7
+//}
+
+module attributes {dlti.dl_spec = #dlti.dl_spec<#dlti.dl_entry<f128, dense<128> : vector<2xi32>>, #dlti.dl_entry<f64, dense<64> : vector<2xi32>>, #dlti.dl_entry<f16, dense<16> : vector<2xi32>>, #dlti.dl_entry<i64, dense<[32, 64]> : vector<2xi32>>, #dlti.dl_entry<i32, dense<32> : vector<2xi32>>, #dlti.dl_entry<i16, dense<16> : vector<2xi32>>, #dlti.dl_entry<i8, dense<8> : vector<2xi32>>, #dlti.dl_entry<i1, dense<8> : vector<2xi32>>, #dlti.dl_entry<!llvm.ptr, dense<64> : vector<4xi32>>, #dlti.dl_entry<"dlti.endianness", "little">>} {
+  llvm.func local_unnamed_addr @_Z2f1ddd(%arg0: f64, %arg1: f64, %arg2: f64) -> f64 {
+    %0 = llvm.fmul %arg1, %arg2  : f64
+    %1 = llvm.fadd %0, %arg0  : f64
+    llvm.return %1 : f64
+  }
+  llvm.func local_unnamed_addr @_Z2f2ddd(%arg0: f64, %arg1: f64, %arg2: f64) -> f64 {
+    %0 = llvm.fmul %arg1, %arg2  : f64
+    %1 = llvm.fsub %arg0, %0  : f64
+    llvm.return %1 : f64
+  }
+  llvm.func local_unnamed_addr @_Z2f3ddd(%arg0: f64, %arg1: f64, %arg2: f64) -> f64 {
+    %0 = llvm.fmul %arg1, %arg2  : f64
+    %1 = llvm.fsub %0, %arg0  : f64
+    llvm.return %1 : f64
+  }
+  llvm.func local_unnamed_addr @_Z2f4ddd(%arg0: f64, %arg1: f64, %arg2: f64) -> f64 {
+    %0 = llvm.fdiv %arg1, %arg2  : f64
+    %1 = llvm.fadd %0, %arg0  : f64
+    llvm.return %1 : f64
+  }
+  llvm.func local_unnamed_addr @_Z2f5ddd(%arg0: f64, %arg1: f64, %arg2: f64) -> f64 {
+    %0 = llvm.fadd %arg0, %arg1  : f64
+    %1 = llvm.fadd %0, %arg2  : f64
+    llvm.return %1 : f64
+  }
+  llvm.func local_unnamed_addr @_Z2f6ddd(%arg0: f64, %arg1: f64, %arg2: f64) -> f64 {
+    %0 = llvm.mlir.constant(1.000000e+00 : f64) : f64
+    %1 = llvm.fmul %arg0, %arg1  : f64
+    %2 = llvm.fadd %1, %arg2  : f64
+    %3 = llvm.fdiv %1, %2  : f64
+    %4 = llvm.fadd %3, %0  : f64
+    llvm.return %4 : f64
+  }
+}
+
+// COM: f1
+// COM: expect fma
+// CHECK: llvm.func local_unnamed_addr @_Z2f1ddd(%arg0: f64, %arg1: f64, %arg2: f64) -> f64 {
+// CHECK-NEXT: %0 = llvm.intr.fma(%arg1, %arg2, %arg0)  : (f64, f64, f64) -> f64
+// CHECK-NEXT: llvm.return %0 : f64
+
+// COM: f2
+// COM: expect fma
+// COM: fma(-b, c, a)
+// CHECK: llvm.func local_unnamed_addr @_Z2f2ddd(%arg0: f64, %arg1: f64, %arg2: f64) -> f64 {
+// CHECK-NEXT: %0 = llvm.fneg %arg1  : f64
+// CHECK-NEXT: %1 = llvm.intr.fma(%0, %arg2, %arg0)  : (f64, f64, f64) -> f64
+// CHECK-NEXT: llvm.return %1 : f64
+
+// COM: f3
+// COM: expect fma
+// COM: fma(b, c, -a)
+// CHECK: llvm.func local_unnamed_addr @_Z2f3ddd(%arg0: f64, %arg1: f64, %arg2: f64) -> f64 {
+// CHECK-NEXT: %0 = llvm.fneg %arg0  : f64
+// CHECK-NEXT: %1 = llvm.intr.fma(%arg1, %arg2, %0)  : (f64, f64, f64) -> f64
+// CHECK-NEXT: llvm.return %1 : f64
+
+// COM: f4
+// COM: no fma
+// CHECK: llvm.func local_unnamed_addr @_Z2f4ddd(%arg0: f64, %arg1: f64, %arg2: f64) -> f64 {
+// CHECK-NEXT: %0 = llvm.fdiv %arg1, %arg2  : f64
+// CHECK-NEXT: %1 = llvm.fadd %0, %arg0  : f64
+// CHECK-NEXT: llvm.return %1 : f64
+
+// COM: f5
+// COM: no fma
+// CHECK: llvm.func local_unnamed_addr @_Z2f5ddd(%arg0: f64, %arg1: f64, %arg2: f64) -> f64 {
+// CHECK-NEXT: %0 = llvm.fadd %arg0, %arg1  : f64
+// CHECK-NEXT: %1 = llvm.fadd %0, %arg2  : f64
+// CHECK-NEXT: llvm.return %1 : f64
+
+// COM: f6
+// COM: expect fma and keep e fmul result
+// CHECK: llvm.func local_unnamed_addr @_Z2f6ddd(%arg0: f64, %arg1: f64, %arg2: f64) -> f64 {
+// CHECK-NEXT: %0 = llvm.mlir.constant(1.000000e+00 : f64) : f64
+// CHECK-NEXT: %1 = llvm.fmul %arg0, %arg1  : f64
+// CHECK-NEXT: %2 = llvm.intr.fma(%arg0, %arg1, %arg2)  : (f64, f64, f64) -> f64
+// CHECK-NEXT: %3 = llvm.fdiv %1, %2  : f64
+// CHECK-NEXT: %4 = llvm.fadd %3, %0  : f64
+// CHECK-NEXT: llvm.return %4 : f64

--- a/mlir/test/Transforms/lab4/kulagin_aleksandr/test.mlir
+++ b/mlir/test/Transforms/lab4/kulagin_aleksandr/test.mlir
@@ -33,6 +33,12 @@
 //  double f = d / e + 1;
 //  return f;
 //}
+//
+//double f7(double a, double b) {
+//  double c = a * b;
+//  double d = c + c;
+//  return d;
+//}
 
 //------------llvm ir
 
@@ -69,9 +75,15 @@
 //define dso_local double @_Z2f6ddd(double %0, double %1, double %2) local_unnamed_addr {
 //  %4 = fmul double %0, %1
 //  %5 = fadd double %4, %2
-//  %6 = fdiv double %4, %5
+//  %6 = fdiv double %5, %4
 //  %7 = fadd double %6, 1.000000e+00
 //  ret double %7
+//}
+//
+//define dso_local double @_Z2f7dd(double %0, double %1) local_unnamed_addr {
+//  %3 = fmul double %0, %1
+//  %4 = fadd double %3, %3
+//  ret double %4
 //}
 
 module attributes {dlti.dl_spec = #dlti.dl_spec<#dlti.dl_entry<f128, dense<128> : vector<2xi32>>, #dlti.dl_entry<f64, dense<64> : vector<2xi32>>, #dlti.dl_entry<f16, dense<16> : vector<2xi32>>, #dlti.dl_entry<i64, dense<[32, 64]> : vector<2xi32>>, #dlti.dl_entry<i32, dense<32> : vector<2xi32>>, #dlti.dl_entry<i16, dense<16> : vector<2xi32>>, #dlti.dl_entry<i8, dense<8> : vector<2xi32>>, #dlti.dl_entry<i1, dense<8> : vector<2xi32>>, #dlti.dl_entry<!llvm.ptr, dense<64> : vector<4xi32>>, #dlti.dl_entry<"dlti.endianness", "little">>} {
@@ -104,9 +116,14 @@ module attributes {dlti.dl_spec = #dlti.dl_spec<#dlti.dl_entry<f128, dense<128> 
     %0 = llvm.mlir.constant(1.000000e+00 : f64) : f64
     %1 = llvm.fmul %arg0, %arg1  : f64
     %2 = llvm.fadd %1, %arg2  : f64
-    %3 = llvm.fdiv %1, %2  : f64
+    %3 = llvm.fdiv %2, %1  : f64
     %4 = llvm.fadd %3, %0  : f64
     llvm.return %4 : f64
+  }
+  llvm.func local_unnamed_addr @_Z2f7dd(%arg0: f64, %arg1: f64) -> f64 {
+    %0 = llvm.fmul %arg0, %arg1  : f64
+    %1 = llvm.fadd %0, %0  : f64
+    llvm.return %1 : f64
   }
 }
 
@@ -152,6 +169,14 @@ module attributes {dlti.dl_spec = #dlti.dl_spec<#dlti.dl_entry<f128, dense<128> 
 // CHECK-NEXT: %0 = llvm.mlir.constant(1.000000e+00 : f64) : f64
 // CHECK-NEXT: %1 = llvm.fmul %arg0, %arg1  : f64
 // CHECK-NEXT: %2 = llvm.intr.fma(%arg0, %arg1, %arg2)  : (f64, f64, f64) -> f64
-// CHECK-NEXT: %3 = llvm.fdiv %1, %2  : f64
+// CHECK-NEXT: %3 = llvm.fdiv %2, %1  : f64
 // CHECK-NEXT: %4 = llvm.fadd %3, %0  : f64
 // CHECK-NEXT: llvm.return %4 : f64
+
+// COM: f7
+// COM: expect fma and keep c fmul result
+// COM: fma(a, b, c)
+// CHECK: llvm.func local_unnamed_addr @_Z2f7dd(%arg0: f64, %arg1: f64) -> f64 {
+// CHECK-NEXT: %0 = llvm.fmul %arg0, %arg1  : f64
+// CHECK-NEXT: %1 = llvm.intr.fma(%arg0, %arg1, %0)  : (f64, f64, f64) -> f64
+// CHECK-NEXT: llvm.return %1 : f64

--- a/mlir/test/Transforms/lab4/kulagin_aleksandr/test.mlir
+++ b/mlir/test/Transforms/lab4/kulagin_aleksandr/test.mlir
@@ -164,19 +164,18 @@ module attributes {dlti.dl_spec = #dlti.dl_spec<#dlti.dl_entry<f128, dense<128> 
 // CHECK-NEXT: llvm.return %1 : f64
 
 // COM: f6
-// COM: expect fma and keep e fmul result
+// COM: expect no fma (don't just replace fadd with fma)
 // CHECK: llvm.func local_unnamed_addr @_Z2f6ddd(%arg0: f64, %arg1: f64, %arg2: f64) -> f64 {
 // CHECK-NEXT: %0 = llvm.mlir.constant(1.000000e+00 : f64) : f64
 // CHECK-NEXT: %1 = llvm.fmul %arg0, %arg1  : f64
-// CHECK-NEXT: %2 = llvm.intr.fma(%arg0, %arg1, %arg2)  : (f64, f64, f64) -> f64
+// CHECK-NEXT: %2 = llvm.fadd %1, %arg2  : f64
 // CHECK-NEXT: %3 = llvm.fdiv %2, %1  : f64
 // CHECK-NEXT: %4 = llvm.fadd %3, %0  : f64
 // CHECK-NEXT: llvm.return %4 : f64
 
 // COM: f7
-// COM: expect fma and keep c fmul result
-// COM: fma(a, b, c)
+// COM: expect no fma (don't just replace fadd with fma)
 // CHECK: llvm.func local_unnamed_addr @_Z2f7dd(%arg0: f64, %arg1: f64) -> f64 {
 // CHECK-NEXT: %0 = llvm.fmul %arg0, %arg1  : f64
-// CHECK-NEXT: %1 = llvm.intr.fma(%arg0, %arg1, %0)  : (f64, f64, f64) -> f64
+// CHECK-NEXT: %1 = llvm.fadd %0, %0  : f64
 // CHECK-NEXT: llvm.return %1 : f64


### PR DESCRIPTION
Has features:
- A support for `d = a - b * c` and `d = b * c - a`.
- If the result of a `fadd` or `fsub` operation is not used anywhere else, we can safely delete it.

Issues:
- Works correctly with `-O1`+. With `-O0` I cannot bypass `store` operation because I can't catch it with `getDefiningOp`. I can catch `load` operation, but it's operand is not a result of `fadd`. It's a result of `alloca`, so it's useless. I hope it's okay.