### PR TITLE
Pushkarev Ilya / lab 3 / opt 1

### DIFF
--- a/llvm/lib/Target/X86/lab3/pushkarev_ilya/CMakeLists.txt
+++ b/llvm/lib/Target/X86/lab3/pushkarev_ilya/CMakeLists.txt
@@ -1,0 +1,13 @@
+set(PluginName PushkarevX86PassFMA)
+
+file(GLOB_RECURSE ALL_SOURCE_FILES *.cpp)
+add_llvm_pass_plugin(${PluginName}
+    ${ALL_SOURCE_FILES}     
+    DEPENDS
+    intrinsics_gen
+    X86
+    BUILDTREE_ONLY)
+
+target_include_directories(${PluginName} PUBLIC ${PATH_TO_X86})
+
+set(LLVM_TEST_DEPENDS ${PluginName} ${LLVM_TEST_DEPENDS} PARENT_SCOPE)

--- a/llvm/lib/Target/X86/lab3/pushkarev_ilya/X86PushkarevPassFMA.cpp
+++ b/llvm/lib/Target/X86/lab3/pushkarev_ilya/X86PushkarevPassFMA.cpp
@@ -1,0 +1,75 @@
+#include "X86.h"
+#include "X86InstrInfo.h"
+#include "llvm/CodeGen/MachineBasicBlock.h"
+#include "llvm/CodeGen/MachineFunctionPass.h"
+#include "llvm/CodeGen/MachineInstr.h"
+#include "llvm/CodeGen/MachineInstrBuilder.h"
+#include "llvm/CodeGen/Register.h"
+#include <utility>
+#include <vector>
+
+using namespace llvm;
+
+namespace {
+class PushkarevX86PassFMA : public MachineFunctionPass {
+public:
+  static char ID;
+
+  PushkarevX86PassFMA() : MachineFunctionPass(ID) {}
+
+  bool runOnMachineFunction(MachineFunction &MF) override {
+    bool modified = false;
+    const TargetInstrInfo *TII = MF.getSubtarget().getInstrInfo();
+    std::vector<std::pair<MachineInstr *, MachineInstr *>> toReplace;
+
+    for (MachineBasicBlock &MBB : MF) {
+      for (auto Instr = MBB.begin(); Instr != MBB.end(); ++Instr) {
+        MachineInstr *MulInstr = &(*Instr);
+
+        if (MulInstr->getOpcode() == X86::MULPDrr ||
+            MulInstr->getOpcode() == X86::MULPDrm) {
+          MachineInstr *AddInstr = nullptr;
+          Register MulDestReg = MulInstr->getOperand(0).getReg();
+
+          for (auto NextInstr = std::next(Instr); NextInstr != MBB.end();
+               ++NextInstr) {
+            if ((NextInstr->getOpcode() == X86::ADDPDrr ||
+                 NextInstr->getOpcode() == X86::ADDPDrm) &&
+                MulDestReg == NextInstr->getOperand(1).getReg()) {
+              AddInstr = &(*NextInstr);
+              break;
+            }
+          }
+
+          if (AddInstr && MulDestReg != AddInstr->getOperand(2).getReg()) {
+            toReplace.emplace_back(MulInstr, AddInstr);
+          }
+        }
+      }
+    }
+
+    for (auto &[MulInstr, AddInstr] : toReplace) {
+      MachineBasicBlock &MBB = *MulInstr->getParent();
+      MIMetadata MetaData(*MulInstr);
+
+      BuildMI(MBB, MulInstr, MetaData, TII->get(X86::VFMADD213PDr),
+              AddInstr->getOperand(0).getReg())
+          .addReg(MulInstr->getOperand(1).getReg())  // a
+          .addReg(MulInstr->getOperand(2).getReg())  // b
+          .addReg(AddInstr->getOperand(2).getReg()); // c
+
+      MulInstr->eraseFromParent();
+      AddInstr->eraseFromParent();
+
+      modified = true;
+    }
+
+    return modified;
+  }
+};
+
+char PushkarevX86PassFMA::ID = 0;
+} // namespace
+
+static RegisterPass<PushkarevX86PassFMA>
+    X("pushkarev-x86-pass-fma", "Multiply-Add Optimization Pass", false, false);

--- a/llvm/test/lab3/pushkarev_ilya/test.mir
+++ b/llvm/test/lab3/pushkarev_ilya/test.mir
@@ -1,0 +1,245 @@
+# RUN: llc -mtriple x86_64-unknown-linux-gnu --load=%llvmshlibdir/PushkarevX86PassFMA%shlibext -run-pass=pushkarev-x86-pass-fma %s -o - | FileCheck %s
+
+## tmp.cpp
+#
+##include <immintrin.h>
+#
+#__m128d muladd1(__m128d a, __m128d b, __m128d c) {
+#    return a * b + c;
+#}
+#
+#__m128d muladd2(__m128d a, __m128d b, __m128d c) {
+#    __m128d tmp = a * b;
+#    return tmp + c;
+#}
+#
+#__m128d muladd3(__m128d a) {
+#    return a * a + a;
+#}
+#
+#__m128d muladd4(__m128d a, __m128d b, __m128d c) {
+#    __m128d tmp = a * b;
+#    __m128d foo1 = _mm_setzero_pd();
+#    __m128d foo2 = _mm_setzero_pd();
+#    return tmp + c;
+#}
+#
+#__m128d muladd5(__m128d a, __m128d b, __m128d c) {
+#    __m128d tmp = a * b * c;
+#    return tmp + c;
+#}
+#
+
+--- |
+  ; ModuleID = 'tmp.ll'
+  source_filename = "tmp.cpp"
+  target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128"
+  target triple = "x86_64-pc-linux-gnu"
+  
+  ; Function Attrs: mustprogress nofree nosync nounwind willreturn memory(none) uwtable
+  define dso_local noundef <2 x double> @_Z7muladd1Dv2_dS_S_(<2 x double> noundef %0, <2 x double> noundef %1, <2 x double> noundef %2) local_unnamed_addr #0 {
+    %4 = tail call <2 x double> @llvm.fmuladd.v2f64(<2 x double> %0, <2 x double> %1, <2 x double> %2)
+    ret <2 x double> %4
+  }
+  
+  ; Function Attrs: nocallback nofree nosync nounwind speculatable willreturn memory(none)
+  declare <2 x double> @llvm.fmuladd.v2f64(<2 x double>, <2 x double>, <2 x double>) #1
+  
+  ; Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(none) uwtable
+  define dso_local noundef <2 x double> @_Z7muladd2Dv2_dS_S_(<2 x double> noundef %0, <2 x double> noundef %1, <2 x double> noundef %2) local_unnamed_addr #2 {
+    %4 = fmul <2 x double> %0, %1
+    %5 = fadd <2 x double> %4, %2
+    ret <2 x double> %5
+  }
+  
+  ; Function Attrs: mustprogress nofree nosync nounwind willreturn memory(none) uwtable
+  define dso_local noundef <2 x double> @_Z7muladd3Dv2_d(<2 x double> noundef %0) local_unnamed_addr #0 {
+    %2 = tail call <2 x double> @llvm.fmuladd.v2f64(<2 x double> %0, <2 x double> %0, <2 x double> %0)
+    ret <2 x double> %2
+  }
+  
+  ; Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(none) uwtable
+  define dso_local noundef <2 x double> @_Z7muladd4Dv2_dS_S_(<2 x double> noundef %0, <2 x double> noundef %1, <2 x double> noundef %2) local_unnamed_addr #2 {
+    %4 = fmul <2 x double> %0, %1
+    %5 = fadd <2 x double> %4, %2
+    ret <2 x double> %5
+  }
+  
+  ; Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(none) uwtable
+  define dso_local noundef <2 x double> @_Z7muladd5Dv2_dS_S_(<2 x double> noundef %0, <2 x double> noundef %1, <2 x double> noundef %2) local_unnamed_addr #2 {
+    %4 = fmul <2 x double> %0, %1
+    %5 = fmul <2 x double> %4, %2
+    %6 = fadd <2 x double> %5, %2
+    ret <2 x double> %6
+  }
+  
+  attributes #0 = { mustprogress nofree nosync nounwind willreturn memory(none) uwtable "frame-pointer"="none" "min-legal-vector-width"="128" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "tune-cpu"="generic" }
+  attributes #1 = { nocallback nofree nosync nounwind speculatable willreturn memory(none) }
+  attributes #2 = { mustprogress nofree norecurse nosync nounwind willreturn memory(none) uwtable "frame-pointer"="none" "min-legal-vector-width"="128" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "tune-cpu"="generic" }
+  
+  !llvm.module.flags = !{!0, !1, !2, !3}
+  !llvm.ident = !{!4}
+  
+  !0 = !{i32 1, !"wchar_size", i32 4}
+  !1 = !{i32 8, !"PIC Level", i32 2}
+  !2 = !{i32 7, !"PIE Level", i32 2}
+  !3 = !{i32 7, !"uwtable", i32 1}
+  !4 = !{!"Ubuntu clang version 14.0.0-1ubuntu1.1"}
+
+...
+---
+name:            _Z7muladd1Dv2_dS_S_
+alignment:       16
+tracksRegLiveness: true
+debugInstrRef:   true
+registers:
+  - { id: 0, class: vr128 }
+  - { id: 1, class: vr128 }
+  - { id: 2, class: vr128 }
+  - { id: 3, class: vr128 }
+  - { id: 4, class: vr128 }
+liveins:
+  - { reg: '$xmm0', virtual-reg: '%0' }
+  - { reg: '$xmm1', virtual-reg: '%1' }
+  - { reg: '$xmm2', virtual-reg: '%2' }
+frameInfo:
+  maxAlignment:    1
+machineFunctionInfo: {}
+body:             |
+  bb.0 (%ir-block.3):
+    liveins: $xmm0, $xmm1, $xmm2
+  
+    %2:vr128 = COPY $xmm2
+    %1:vr128 = COPY $xmm1
+    %0:vr128 = COPY $xmm0
+    %3:vr128 = nofpexcept MULPDrr %0, %1, implicit $mxcsr
+    %4:vr128 = nofpexcept ADDPDrr %3, %2, implicit $mxcsr
+    ; CHECK: %4:vr128 = VFMADD213PDr %0, %1, %2, implicit $mxcsr
+    $xmm0 = COPY %4
+    RET 0, $xmm0
+
+...
+---
+name:            _Z7muladd2Dv2_dS_S_
+alignment:       16
+tracksRegLiveness: true
+debugInstrRef:   true
+registers:
+  - { id: 0, class: vr128 }
+  - { id: 1, class: vr128 }
+  - { id: 2, class: vr128 }
+  - { id: 3, class: vr128 }
+  - { id: 4, class: vr128 }
+liveins:
+  - { reg: '$xmm0', virtual-reg: '%0' }
+  - { reg: '$xmm1', virtual-reg: '%1' }
+  - { reg: '$xmm2', virtual-reg: '%2' }
+frameInfo:
+  maxAlignment:    1
+machineFunctionInfo: {}
+body:             |
+  bb.0 (%ir-block.3):
+    liveins: $xmm0, $xmm1, $xmm2
+  
+    %2:vr128 = COPY $xmm2
+    %1:vr128 = COPY $xmm1
+    %0:vr128 = COPY $xmm0
+    %3:vr128 = nofpexcept MULPDrr %0, %1, implicit $mxcsr
+    %4:vr128 = nofpexcept ADDPDrr %3, %2, implicit $mxcsr
+    $xmm0 = COPY %4
+    RET 0, $xmm0
+
+...
+---
+name:            _Z7muladd3Dv2_d
+alignment:       16
+tracksRegLiveness: true
+debugInstrRef:   true
+registers:
+  - { id: 0, class: vr128 }
+  - { id: 1, class: vr128 }
+  - { id: 2, class: vr128 }
+liveins:
+  - { reg: '$xmm0', virtual-reg: '%0' }
+frameInfo:
+  maxAlignment:    1
+machineFunctionInfo: {}
+body:             |
+  bb.0 (%ir-block.1):
+    liveins: $xmm0
+  
+    %0:vr128 = COPY $xmm0
+    %1:vr128 = nofpexcept MULPDrr %0, %0, implicit $mxcsr
+    %2:vr128 = nofpexcept ADDPDrr %1, %0, implicit $mxcsr
+    ;CHECK : %4:vr128 = VFMADD213PDr %0, %1, %2, implicit $mxcsr
+    $xmm0 = COPY %2
+    RET 0, $xmm0
+
+...
+---
+name:            _Z7muladd4Dv2_dS_S_
+alignment:       16
+tracksRegLiveness: true
+debugInstrRef:   true
+registers:
+  - { id: 0, class: vr128 }
+  - { id: 1, class: vr128 }
+  - { id: 2, class: vr128 }
+  - { id: 3, class: vr128 }
+  - { id: 4, class: vr128 }
+liveins:
+  - { reg: '$xmm0', virtual-reg: '%0' }
+  - { reg: '$xmm1', virtual-reg: '%1' }
+  - { reg: '$xmm2', virtual-reg: '%2' }
+frameInfo:
+  maxAlignment:    1
+machineFunctionInfo: {}
+body:             |
+  bb.0 (%ir-block.3):
+    liveins: $xmm0, $xmm1, $xmm2
+  
+    %2:vr128 = COPY $xmm2
+    %1:vr128 = COPY $xmm1
+    %0:vr128 = COPY $xmm0
+    %3:vr128 = nofpexcept MULPDrr %0, %1, implicit $mxcsr
+    %4:vr128 = nofpexcept ADDPDrr %3, %2, implicit $mxcsr
+    ; CHECK : %2:vr128 = VFMADD213PDr %0, %0, %0, implicit $mxcsr
+    $xmm0 = COPY %4
+    RET 0, $xmm0
+
+...
+---
+name:            _Z7muladd5Dv2_dS_S_
+alignment:       16
+tracksRegLiveness: true
+debugInstrRef:   true
+registers:
+  - { id: 0, class: vr128 }
+  - { id: 1, class: vr128 }
+  - { id: 2, class: vr128 }
+  - { id: 3, class: vr128 }
+  - { id: 4, class: vr128 }
+  - { id: 5, class: vr128 }
+liveins:
+  - { reg: '$xmm0', virtual-reg: '%0' }
+  - { reg: '$xmm1', virtual-reg: '%1' }
+  - { reg: '$xmm2', virtual-reg: '%2' }
+frameInfo:
+  maxAlignment:    1
+machineFunctionInfo: {}
+body:             |
+  bb.0 (%ir-block.3):
+    liveins: $xmm0, $xmm1, $xmm2
+  
+    %2:vr128 = COPY $xmm2
+    %1:vr128 = COPY $xmm1
+    %0:vr128 = COPY $xmm0
+    %3:vr128 = nofpexcept MULPDrr %0, %1, implicit $mxcsr
+    %4:vr128 = nofpexcept MULPDrr %3, %2, implicit $mxcsr
+    %5:vr128 = nofpexcept ADDPDrr %4, %2, implicit $mxcsr
+    ; CHECK : %4:vr128 = VFMADD213PDr %0, %1, %2, implicit $mxcsr
+    $xmm0 = COPY %5
+    RET 0, $xmm0
+
+...
+


### PR DESCRIPTION
In a backend write an optimization pass that replaces multiplication and addition operation:
tmp = a * b;
d = tmp + c;
with muladd instruction:
d = muladd(a, b, c);

It would be nice to implement via MachineFunction pass after Instruction selection step, but before regalloc

For x86 arch such instruction example is vfmadd213pd(...). Possible sample to use is:

#include <immintrin.h>

__m128d muladd(__m128d a, __m128d b, __m128d c) {
    return a * b + c;
}

You can generate LLVM IR with option -O2 to remove some extra load/store instructions complicating analysis.