### PR TITLE
Pivovarov Alexey. Lab 1. Opt 2.

### DIFF
--- a/clang/labs/lab1/pivovarov_alexey/CMakeLists.txt
+++ b/clang/labs/lab1/pivovarov_alexey/CMakeLists.txt
@@ -1,0 +1,14 @@
+add_llvm_library(PivovarovAlwaysInlinePlugin MODULE PivovarovAlwaysInline.cpp PLUGIN_TOOL clang)
+
+if(WIN32 OR CYGWIN)
+  set(LLVM_LINK_COMPONENTS
+    Support
+  )
+  clang_target_link_libraries(PivovarovAlwaysInlinePlugin PRIVATE
+    clangAST
+    clangBasic
+    clangFrontend
+    )
+endif()
+
+set(CLANG_TEST_DEPS "PivovarovAlwaysInlinePlugin" ${CLANG_TEST_DEPS} PARENT_SCOPE)

--- a/clang/labs/lab1/pivovarov_alexey/PivovarovAlwaysInline.cpp
+++ b/clang/labs/lab1/pivovarov_alexey/PivovarovAlwaysInline.cpp
@@ -1,0 +1,69 @@
+#include "clang/AST/AST.h"
+#include "clang/AST/ASTConsumer.h"
+#include "clang/AST/Decl.h"
+#include "clang/AST/DeclGroup.h"
+#include "clang/AST/RecursiveASTVisitor.h"
+#include "clang/AST/Stmt.h"
+#include "clang/Basic/SourceLocation.h"
+#include "clang/Frontend/CompilerInstance.h"
+#include "clang/Frontend/FrontendPluginRegistry.h"
+#include "llvm/ADT/StringRef.h"
+#include <queue>
+
+class AlwaysInlineConsumer : public clang::ASTConsumer {
+public:
+    bool HandleTopLevelDecl(clang::DeclGroupRef DeclGroup) override {
+        for (clang::Decl* Decl : DeclGroup) {
+            if (clang::isa<clang::FunctionDecl>(Decl)) {
+                if (Decl->getAttr<clang::AlwaysInlineAttr>()) {
+                    continue;
+                }
+                clang::Stmt* Body = Decl->getBody();
+                if (Body != nullptr) {
+                    bool CondFound = false;
+                    std::queue<clang::Stmt*> StQueue;
+                    StQueue.push(Body);
+                    while (!StQueue.empty() && !CondFound) {
+                        clang::Stmt* St = StQueue.front();
+                        StQueue.pop();
+                        if (clang::isa<clang::IfStmt>(St) ||
+                            clang::isa<clang::WhileStmt>(St) ||
+                            clang::isa<clang::ForStmt>(St) ||
+                            clang::isa<clang::DoStmt>(St) ||
+                            clang::isa<clang::SwitchStmt>(St)) {
+                            CondFound = true;
+                            break;
+                        }
+                        for (clang::Stmt* StCh : St->children()) {
+                            StQueue.push(StCh);
+                        }
+                    }
+                    if (!CondFound) {
+                        clang::SourceLocation Location(Decl->getSourceRange().getBegin());
+                        clang::SourceRange Range(Location);
+                        Decl->addAttr(
+                            clang::AlwaysInlineAttr::Create(Decl->getASTContext(), Range));
+                    }
+                }
+            }
+        }
+        return true;
+    }
+};
+
+class AlwaysInlinePlugin : public clang::PluginASTAction {
+protected:
+    std::unique_ptr<clang::ASTConsumer>
+        CreateASTConsumer(clang::CompilerInstance& Compiler,
+            llvm::StringRef InFile) override {
+        return std::make_unique<AlwaysInlineConsumer>();
+    }
+    bool ParseArgs(const clang::CompilerInstance& Compiler,
+        const std::vector<std::string>& Args) override {
+        return true;
+    }
+};
+
+static clang::FrontendPluginRegistry::Add<AlwaysInlinePlugin>
+X("always-inline-plugin",
+    "Print a function without conditions with an attribute");

--- a/clang/labs/lab1/pivovarov_alexey/PivovarovAlwaysInline.cpp
+++ b/clang/labs/lab1/pivovarov_alexey/PivovarovAlwaysInline.cpp
@@ -1,69 +1,62 @@
-#include "clang/AST/AST.h"
 #include "clang/AST/ASTConsumer.h"
+#include "clang/AST/Attr.h"
 #include "clang/AST/Decl.h"
-#include "clang/AST/DeclGroup.h"
-#include "clang/AST/RecursiveASTVisitor.h"
 #include "clang/AST/Stmt.h"
-#include "clang/Basic/SourceLocation.h"
-#include "clang/Frontend/CompilerInstance.h"
 #include "clang/Frontend/FrontendPluginRegistry.h"
-#include "llvm/ADT/StringRef.h"
+#include "clang/Plugin/ASTAction.h"
 #include <queue>
 
 class AlwaysInlineConsumer : public clang::ASTConsumer {
 public:
-    bool HandleTopLevelDecl(clang::DeclGroupRef DeclGroup) override {
-        for (clang::Decl* Decl : DeclGroup) {
-            if (clang::isa<clang::FunctionDecl>(Decl)) {
-                if (Decl->getAttr<clang::AlwaysInlineAttr>()) {
-                    continue;
-                }
-                clang::Stmt* Body = Decl->getBody();
-                if (Body != nullptr) {
-                    bool CondFound = false;
-                    std::queue<clang::Stmt*> StQueue;
-                    StQueue.push(Body);
-                    while (!StQueue.empty() && !CondFound) {
-                        clang::Stmt* St = StQueue.front();
-                        StQueue.pop();
-                        if (clang::isa<clang::IfStmt>(St) ||
-                            clang::isa<clang::WhileStmt>(St) ||
-                            clang::isa<clang::ForStmt>(St) ||
-                            clang::isa<clang::DoStmt>(St) ||
-                            clang::isa<clang::SwitchStmt>(St)) {
-                            CondFound = true;
-                            break;
-                        }
-                        for (clang::Stmt* StCh : St->children()) {
-                            StQueue.push(StCh);
-                        }
-                    }
-                    if (!CondFound) {
-                        clang::SourceLocation Location(Decl->getSourceRange().getBegin());
-                        clang::SourceRange Range(Location);
-                        Decl->addAttr(
-                            clang::AlwaysInlineAttr::Create(Decl->getASTContext(), Range));
-                    }
-                }
-            }
+  bool HandleTopLevelDecl(clang::DeclGroupRef DeclGroup) override {
+    for (clang::Decl *Decl : DeclGroup) {
+      if (clang::isa<clang::FunctionDecl>(Decl)) {
+        if (Decl->getAttr<clang::AlwaysInlineAttr>()) {
+          continue;
         }
-        return true;
+        clang::Stmt *Body = Decl->getBody();
+        if (Body != nullptr) {
+          bool CondFound = false;
+          std::queue<clang::Stmt *> StQueue;
+          StQueue.push(Body);
+          while (!StQueue.empty() && !CondFound) {
+            clang::Stmt *St = StQueue.front();
+            StQueue.pop();
+            if (clang::isa<clang::IfStmt>(St) || clang::isa<clang::WhileStmt>(St) ||
+                clang::isa<clang::ForStmt>(St) || clang::isa<clang::DoStmt>(St) ||
+                clang::isa<clang::SwitchStmt>(St)) {
+              CondFound = true;
+              break;
+            }
+            for (clang::Stmt *StCh : St->children()) {
+              StQueue.push(StCh);
+            }
+          }
+          if (!CondFound) {
+            clang::SourceLocation Location(Decl->getSourceRange().getBegin());
+            clang::SourceRange Range(Location);
+            Decl->addAttr(clang::AlwaysInlineAttr::Create(Decl->getASTContext(), Range));
+          }
+        }
+      }
     }
+    return true;
+  }
 };
 
 class AlwaysInlinePlugin : public clang::PluginASTAction {
 protected:
-    std::unique_ptr<clang::ASTConsumer>
-        CreateASTConsumer(clang::CompilerInstance& Compiler,
-            llvm::StringRef InFile) override {
-        return std::make_unique<AlwaysInlineConsumer>();
-    }
-    bool ParseArgs(const clang::CompilerInstance& Compiler,
-        const std::vector<std::string>& Args) override {
-        return true;
-    }
+  std::unique_ptr<clang::ASTConsumer>
+  CreateASTConsumer(clang::CompilerInstance &Compiler,
+                    llvm::StringRef InFile) override {
+    return std::make_unique<AlwaysInlineConsumer>();
+  }
+
+  bool ParseArgs(const clang::CompilerInstance &Compiler,
+                 const std::vector<std::string> &Args) override {
+    return true;
+  }
 };
 
 static clang::FrontendPluginRegistry::Add<AlwaysInlinePlugin>
-X("always-inline-plugin",
-    "Print a function without conditions with an attribute");
+    X("always-inline-plugin", "Print a function without conditions with an attribute");

--- a/clang/labs/lab1/pivovarov_alexey/PivovarovAlwaysInline.cpp
+++ b/clang/labs/lab1/pivovarov_alexey/PivovarovAlwaysInline.cpp
@@ -2,8 +2,8 @@
 #include "clang/AST/Attr.h"
 #include "clang/AST/Decl.h"
 #include "clang/AST/Stmt.h"
+#include "clang/Frontend/FrontendAction.h"
 #include "clang/Frontend/FrontendPluginRegistry.h"
-#include "clang/Plugin/ASTAction.h"
 #include <queue>
 
 class AlwaysInlineConsumer : public clang::ASTConsumer {

--- a/clang/labs/lab1/pivovarov_alexey/PivovarovAlwaysInline.cpp
+++ b/clang/labs/lab1/pivovarov_alexey/PivovarovAlwaysInline.cpp
@@ -22,8 +22,10 @@ public:
           while (!StQueue.empty() && !CondFound) {
             clang::Stmt *St = StQueue.front();
             StQueue.pop();
-            if (clang::isa<clang::IfStmt>(St) || clang::isa<clang::WhileStmt>(St) ||
-                clang::isa<clang::ForStmt>(St) || clang::isa<clang::DoStmt>(St) ||
+            if (clang::isa<clang::IfStmt>(St) ||
+                clang::isa<clang::WhileStmt>(St) ||
+                clang::isa<clang::ForStmt>(St) ||
+                clang::isa<clang::DoStmt>(St) ||
                 clang::isa<clang::SwitchStmt>(St)) {
               CondFound = true;
               break;
@@ -35,7 +37,8 @@ public:
           if (!CondFound) {
             clang::SourceLocation Location(Decl->getSourceRange().getBegin());
             clang::SourceRange Range(Location);
-            Decl->addAttr(clang::AlwaysInlineAttr::Create(Decl->getASTContext(), Range));
+            Decl->addAttr(
+                clang::AlwaysInlineAttr::Create(Decl->getASTContext(), Range));
           }
         }
       }
@@ -59,4 +62,5 @@ protected:
 };
 
 static clang::FrontendPluginRegistry::Add<AlwaysInlinePlugin>
-    X("always-inline-plugin", "Print a function without conditions with an attribute");
+    X("always-inline-plugin",
+      "Print a function without conditions with an attribute");

--- a/clang/test/lab1/pivovarov_alexey/test.cpp
+++ b/clang/test/lab1/pivovarov_alexey/test.cpp
@@ -1,0 +1,70 @@
+// RUN: %clang_cc1 -ast-dump -ast-dump-filter testFun -load %llvmshlibdir/PivovarovAlwaysInlinePlugin%pluginext -add-plugin always-inline-plugin %s 2>&1 | FileCheck %s
+
+// CHECK: FunctionDecl {{0[xX][0-9a-fA-F]+ <.+test\.cpp:([0-9]+:[0-9]|[0-9]+), (line|col):([0-9]+:[0-9]|[0-9]+)> (line|col):([0-9]+:[0-9]|[0-9]+) testFun1 'int \(int, int\)'}}
+int testFun1(int A, int B) {
+    if (A < B) {
+        A = B;
+    }
+    return 0;
+}
+// CHECK-NOT: `-AlwaysInlineAttr {{0[xX][0-9a-fA-F]+ <(line|col):([0-9]+:[0-9]|[0-9]+)> Implicit always_inline}}
+
+// CHECK: FunctionDecl {{0[xX][0-9a-fA-F]+ <.+test\.cpp:([0-9]+:[0-9]|[0-9]+), (line|col):([0-9]+:[0-9]|[0-9]+)> (line|col):([0-9]+:[0-9]|[0-9]+) testFun2 'void \(int, int\)'}}
+void testFun2(int A, int B) {
+    {
+        while (A < B) {
+            A = B;
+        }
+    }
+}
+// CHECK-NOT: `-AlwaysInlineAttr {{0[xX][0-9a-fA-F]+ <(line|col):([0-9]+:[0-9]|[0-9]+)> Implicit always_inline}}
+
+// CHECK: FunctionDecl {{0[xX][0-9a-fA-F]+ <.+test\.cpp:([0-9]+:[0-9]|[0-9]+), (line|col):([0-9]+:[0-9]|[0-9]+)> (line|col):([0-9]+:[0-9]|[0-9]+) testFun3 'int \(\)'}}
+int testFun3() { return 1; }
+// CHECK: `-AlwaysInlineAttr {{0[xX][0-9a-fA-F]+ <(line|col):([0-9]+:[0-9]|[0-9]+)> always_inline}}
+
+// CHECK: FunctionDecl {{0[xX][0-9a-fA-F]+ <.+test\.cpp:([0-9]+:[0-9]|[0-9]+), (line|col):([0-9]+:[0-9]|[0-9]+)> (line|col):([0-9]+:[0-9]|[0-9]+) testFun4 'void \(char, char\)'}}
+void testFun4(char A, char B) {
+    {
+        {
+            while (true) {
+            }
+        }
+    }
+}
+// CHECK-NOT: `-AlwaysInlineAttr {{0[xX][0-9a-fA-F]+ <(line|col):([0-9]+:[0-9]|[0-9]+)> Implicit always_inline}}
+
+// CHECK: FunctionDecl {{0[xX][0-9a-fA-F]+ <.+test\.cpp:([0-9]+:[0-9]|[0-9]+), (line|col):([0-9]+:[0-9]|[0-9]+)> (line|col):([0-9]+:[0-9]|[0-9]+) testFun5 'int \(int\)'}}
+int testFun5(int A) {
+    for (int i = 0; i < 0; i++) {
+    }
+
+    return A;
+}
+// CHECK-NOT: `-AlwaysInlineAttr {{0[xX][0-9a-fA-F]+ <(line|col):([0-9]+:[0-9]|[0-9]+)> Implicit always_inline}}
+
+// CHECK: FunctionDecl {{0[xX][0-9a-fA-F]+ <.+test\.cpp:([0-9]+:[0-9]|[0-9]+), (line|col):([0-9]+:[0-9]|[0-9]+)> (line|col):([0-9]+:[0-9]|[0-9]+) testFun6 'int \(int\)'}}
+int testFun6(int A) {
+    switch (A)
+    {
+    case 1:
+        break;
+
+    default:
+        break;
+    }
+    return A;
+}
+// CHECK-NOT: `-AlwaysInlineAttr {{0[xX][0-9a-fA-F]+ <(line|col):([0-9]+:[0-9]|[0-9]+)> Implicit always_inline}}
+
+// CHECK: FunctionDecl {{0[xX][0-9a-fA-F]+ <.+test\.cpp:([0-9]+:[0-9]|[0-9]+), (line|col):([0-9]+:[0-9]|[0-9]+)> (line|col):([0-9]+:[0-9]|[0-9]+) testFun7 'int \(\)'}}
+int testFun7() {
+    {
+        {
+            {
+            }
+        }
+    }
+    return 0;
+}
+// CHECK: `-AlwaysInlineAttr {{0[xX][0-9a-fA-F]+ <(line|col):([0-9]+:[0-9]|[0-9]+)> always_inline}}


### PR DESCRIPTION
This lab work implements a Clang plugin that automatically adds the AlwaysInline attribute to functions without conditional statements. The AlwaysInlineConsumer class traverses top-level function declarations, checks for the presence of conditional statements, and adds the attribute if none are found. The AlwaysInlinePlugin class sets up the plugin to use this consumer. The plugin is registered and can be invoked with the name "always-inline-plugin".