### PR TITLE
Pivovarov Alexey. Lab 2. Opt 2.

### DIFF
--- a/llvm/labs/lab2/pivovarov_alexey/CMakeLists.txt
+++ b/llvm/labs/lab2/pivovarov_alexey/CMakeLists.txt
@@ -1,0 +1,12 @@
+if (NOT WIN32 AND NOT CYGWIN)
+  set(PluginName AlexeyInliningPass)
+
+  file(GLOB_RECURSE ALL_SOURCE_FILES *.cpp *.h)
+  add_llvm_pass_plugin(${PluginName} 
+  ${ALL_SOURCE_FILES}     
+  DEPENDS
+  intrinsics_gen
+  BUILDTREE_ONLY)
+
+  set(LLVM_TEST_DEPENDS ${PluginName} ${LLVM_TEST_DEPENDS} PARENT_SCOPE)
+endif()

--- a/llvm/labs/lab2/pivovarov_alexey/inline_plugin.cpp
+++ b/llvm/labs/lab2/pivovarov_alexey/inline_plugin.cpp
@@ -1,0 +1,137 @@
+#include "llvm/ADT/SmallPtrSet.h"
+#include "llvm/IR/BasicBlock.h"
+#include "llvm/IR/Function.h"
+#include "llvm/IR/IRBuilder.h"
+#include "llvm/IR/Instructions.h"
+#include "llvm/Passes/PassBuilder.h"
+#include "llvm/Passes/PassPlugin.h"
+#include "llvm/Transforms/Utils/ValueMapper.h"
+
+namespace {
+
+struct AlexeyInliningPass : public llvm::PassInfoMixin<AlexeyInliningPass> {
+  llvm::PreservedAnalyses run(llvm::Function &F,
+                              llvm::FunctionAnalysisManager &) {
+    llvm::SmallVector<llvm::CallInst *, 8> CallsToInline;
+    llvm::IRBuilder<> Builder(F.getContext());
+
+    for (llvm::BasicBlock &BB : F) {
+      for (llvm::Instruction &Instr : BB) {
+        if (auto *CI = llvm::dyn_cast<llvm::CallInst>(&Instr)) {
+          llvm::Function *Callee = CI->getCalledFunction();
+
+          if (Callee && Callee->arg_empty() &&
+              Callee->getReturnType()->isVoidTy()) {
+            CallsToInline.push_back(CI);
+          }
+        }
+      }
+    }
+
+    for (auto *CI : CallsToInline) {
+      llvm::BasicBlock *InsertionBlock = CI->getParent();
+      llvm::ValueToValueMapTy ValueMap;
+
+      llvm::BasicBlock *PostCallBB =
+          InsertionBlock->splitBasicBlock(CI->getIterator(), "post-call");
+
+      llvm::Function *Callee = CI->getCalledFunction();
+      llvm::BasicBlock *PrevBB = nullptr;
+      llvm::BasicBlock *CurrentBB = nullptr;
+      for (llvm::BasicBlock &CalleeBB : *Callee) {
+        CurrentBB =
+            llvm::BasicBlock::Create(F.getContext(), "", &F, PostCallBB);
+        ValueMap[&CalleeBB] = CurrentBB;
+
+        Builder.SetInsertPoint(CurrentBB);
+        for (llvm::Instruction &Inst : CalleeBB) {
+          if (!Inst.isTerminator()) {
+            llvm::Instruction *NewInst = Inst.clone();
+            if (!NewInst) {
+              llvm::errs() << "Error: Failed to clone instruction.\\n";
+              return llvm::PreservedAnalyses::none();
+            }
+            Builder.Insert(NewInst);
+            ValueMap[&Inst] = NewInst;
+          }
+        }
+
+        if (PrevBB) {
+          if (PrevBB->getTerminator()) {
+            PrevBB->getTerminator()->eraseFromParent();
+          }
+          Builder.SetInsertPoint(PrevBB);
+          Builder.CreateBr(CurrentBB);
+        }
+
+        PrevBB = CurrentBB;
+      }
+
+      if (PrevBB) {
+        if (PrevBB->getTerminator()) {
+          PrevBB->getTerminator()->eraseFromParent();
+        }
+        Builder.SetInsertPoint(PrevBB);
+        Builder.CreateBr(PostCallBB);
+      }
+
+      for (auto Iter = ValueMap.begin(); Iter != ValueMap.end(); ++Iter) {
+        if (llvm::BasicBlock *NewBB =
+                llvm::dyn_cast<llvm::BasicBlock>(Iter->second)) {
+          for (llvm::Instruction &Inst : *NewBB) {
+            for (llvm::Use &Op : Inst.operands()) {
+              if (ValueMap.count(Op)) {
+                Op.set(ValueMap[Op]);
+              }
+            }
+          }
+        }
+      }
+
+      for (auto &Use : CI->uses()) {
+        llvm::User *User = Use.getUser();
+        for (unsigned i = 0; i < User->getNumOperands(); ++i) {
+          if (ValueMap.count(User->getOperand(i))) {
+            User->getOperand(i)->replaceAllUsesWith(
+                ValueMap[User->getOperand(i)]);
+          }
+        }
+      }
+
+      // Handling branch instructions
+      llvm::BasicBlock *PostCallBBNext = PostCallBB->getNextNode();
+      if (PostCallBBNext) {
+        llvm::Instruction *Term = PostCallBB->getTerminator();
+        Term->eraseFromParent();
+        Builder.SetInsertPoint(PostCallBB);
+        Builder.CreateBr(PostCallBBNext);
+      }
+
+      CI->eraseFromParent();
+    }
+
+    return llvm::PreservedAnalyses::none();
+  }
+};
+
+} // end anonymous namespace
+
+llvm::PassPluginLibraryInfo getAlexeyInliningPassPluginInfo() {
+  return {LLVM_PLUGIN_API_VERSION, "AlexeyInliningPass", "v0.1",
+          [](llvm::PassBuilder &PB) {
+            PB.registerPipelineParsingCallback(
+                [](llvm::StringRef Name, llvm::FunctionPassManager &FPM,
+                   llvm::ArrayRef<llvm::PassBuilder::PipelineElement>) {
+                  if (Name == "alexey-inlining") {
+                    FPM.addPass(AlexeyInliningPass());
+                    return true;
+                  }
+                  return false;
+                });
+          }};
+}
+
+extern "C" LLVM_ATTRIBUTE_WEAK ::llvm::PassPluginLibraryInfo
+llvmGetPassPluginInfo() {
+  return getAlexeyInliningPassPluginInfo();
+}

--- a/llvm/test/lab2/pivovarov_alexey/test.ll
+++ b/llvm/test/lab2/pivovarov_alexey/test.ll
@@ -1,0 +1,225 @@
+; RUN: opt -load-pass-plugin=%llvmshlibdir/AlexeyInliningPass%pluginext -passes=alexey-inlining -S %s | FileCheck %s
+
+;void foo1() {
+;  float a = 1.0f;
+;  a += 1.0f;
+;}
+;
+;void bar1() {
+;  int a = 0;
+;  foo1();
+;  a++;
+;}
+
+define dso_local void @_Z4foo1v() {
+entry:
+  %a = alloca float, align 4
+  store float 1.000000e+00, ptr %a, align 4
+  %0 = load float, ptr %a, align 4
+  %add = fadd float %0, 1.000000e+00
+  store float %add, ptr %a, align 4
+  ret void
+}
+
+define dso_local void @_Z4bar1v() #0 {
+entry:
+  %a = alloca i32, align 4
+  store i32 0, ptr %a, align 4
+  call void @_Z4foo1v()
+  %0 = load i32, ptr %a, align 4
+  %inc = add nsw i32 %0, 1
+  store i32 %inc, ptr %a, align 4
+  ret void
+}
+
+; CHECK: define dso_local void @_Z4bar1v() {
+; CHECK-NEXT: entry:
+; CHECK-NEXT:   %a = alloca i32, align 4
+; CHECK-NEXT:   store i32 0, ptr %a, align 4
+; CHECK-NEXT:   br label %post-call
+; CHECK: 0:                                                
+; CHECK-NEXT:   %1 = alloca float, align 4
+; CHECK-NEXT:   store float 1.000000e+00, ptr %1, align 4
+; CHECK-NEXT:   %2 = load float, ptr %1, align 4
+; CHECK-NEXT:   %3 = fadd float %2, 1.000000e+00
+; CHECK-NEXT:   store float %3, ptr %1, align 4
+; CHECK-NEXT:   br label %post-call
+; CHECK: post-call:                                        
+; CHECK-NEXT:   %4 = load i32, ptr %a, align 4
+; CHECK-NEXT:   %inc = add nsw i32 %4, 1
+; CHECK-NEXT:   store i32 %inc, ptr %a, align 4
+; CHECK-NEXT:   ret void
+; CHECK-NEXT: }
+
+;void foo2(int) {
+;  float a = 1.0f;
+;  a += 1.0f;
+;}
+;
+;void bar2() {
+;  int a = 0;
+;  foo2(a);
+;  a++;
+;}
+
+define dso_local void @_Z4foo2i(i32 noundef %0) #0 {
+entry:
+  %.addr = alloca i32, align 4
+  %a = alloca float, align 4
+  store i32 %0, ptr %.addr, align 4
+  store float 1.000000e+00, ptr %a, align 4
+  %1 = load float, ptr %a, align 4
+  %add = fadd float %1, 1.000000e+00
+  store float %add, ptr %a, align 4
+  ret void
+}
+
+define dso_local void @_Z4bar2v() #0 {
+entry:
+  %a = alloca i32, align 4
+  store i32 0, ptr %a, align 4
+  %0 = load i32, ptr %a, align 4
+  call void @_Z4foo2i(i32 noundef %0)
+  %1 = load i32, ptr %a, align 4
+  %inc = add nsw i32 %1, 1
+  store i32 %inc, ptr %a, align 4
+  ret void
+}
+
+; CHECK: define dso_local void @_Z4bar2v() {
+; CHECK-NEXT: entry:
+; CHECK-NEXT:  %a = alloca i32, align 4
+; CHECK-NEXT:  store i32 0, ptr %a, align 4
+; CHECK-NEXT:  %0 = load i32, ptr %a, align 4
+; CHECK-NEXT:  call void @_Z4foo2i(i32 noundef %0)
+; CHECK-NEXT:  %1 = load i32, ptr %a, align 4
+; CHECK-NEXT:  %inc = add nsw i32 %1, 1
+; CHECK-NEXT:  store i32 %inc, ptr %a, align 4
+; CHECK-NEXT:  ret void
+; CHECK-NEXT: }
+
+;float foo3() {
+;  float a = 1.0f;
+;  a += 1.0f;
+;  return a;
+;}
+;
+;void bar3() {
+;  int a = 0;
+;  foo3();
+;  a++;
+;}
+
+define dso_local noundef float @_Z4foo3v() #0 {
+entry:
+  %a = alloca float, align 4
+  store float 1.000000e+00, ptr %a, align 4
+  %0 = load float, ptr %a, align 4
+  %add = fadd float %0, 1.000000e+00
+  store float %add, ptr %a, align 4
+  %1 = load float, ptr %a, align 4
+  ret float %1
+}
+
+define dso_local void @_Z4bar3v() #0 {
+entry:
+  %a = alloca i32, align 4
+  store i32 0, ptr %a, align 4
+  %call = call noundef float @_Z4foo3v()
+  %0 = load i32, ptr %a, align 4
+  %inc = add nsw i32 %0, 1
+  store i32 %inc, ptr %a, align 4
+  ret void
+}
+
+; CHECK: define dso_local void @_Z4bar3v() {
+; CHECK-NEXT:entry:
+; CHECK-NEXT:  %a = alloca i32, align 4
+; CHECK-NEXT:  store i32 0, ptr %a, align 4
+; CHECK-NEXT:  %call = call noundef float @_Z4foo3v()
+; CHECK-NEXT:  %0 = load i32, ptr %a, align 4
+; CHECK-NEXT:  %inc = add nsw i32 %0, 1
+; CHECK-NEXT:  store i32 %inc, ptr %a, align 4
+; CHECK-NEXT:  ret void
+; CHECK-NEXT:}
+
+;void foo4() {
+;  float a = 1.0f;
+;  if (a < 2.0f)
+;    a += 1.0f;
+;}
+;
+;void bar4() {
+;  int a = 0;
+;  if (a < 1)
+;    foo4();
+;  a++;
+;}
+
+define dso_local void @_Z4foo4v() #0 {
+entry:
+  %a = alloca float, align 4
+  store float 1.000000e+00, ptr %a, align 4
+  %0 = load float, ptr %a, align 4
+  %cmp = fcmp olt float %0, 2.000000e+00
+  br i1 %cmp, label %if.then, label %if.end
+
+if.then:                                          ; preds = %entry
+  %1 = load float, ptr %a, align 4
+  %add = fadd float %1, 1.000000e+00
+  store float %add, ptr %a, align 4
+  br label %if.end
+
+if.end:                                           ; preds = %if.then, %entry
+  ret void
+}
+
+define dso_local void @_Z4bar4v() #0 {
+entry:
+  %a = alloca i32, align 4
+  store i32 0, ptr %a, align 4
+  %0 = load i32, ptr %a, align 4
+  %cmp = icmp slt i32 %0, 1
+  br i1 %cmp, label %if.then, label %if.end
+
+if.then:                                          ; preds = %entry
+  call void @_Z4foo4v()
+  br label %if.end
+
+if.end:                                           ; preds = %if.then, %entry
+  %1 = load i32, ptr %a, align 4
+  %inc = add nsw i32 %1, 1
+  store i32 %inc, ptr %a, align 4
+  ret void
+}
+
+; CHECK: define dso_local void @_Z4bar4v() {
+; CHECK: entry:
+; CHECK-NEXT:   %a = alloca i32, align 4
+; CHECK-NEXT:   store i32 0, ptr %a, align 4
+; CHECK-NEXT:   %0 = load i32, ptr %a, align 4
+; CHECK-NEXT:   %cmp = icmp slt i32 %0, 1
+; CHECK-NEXT:   br i1 %cmp, label %if.then, label %if.end
+; CHECK: if.then:                                          ; preds = %entry
+; CHECK-NEXT:   br label %post-call
+; CHECK: 1:                                                
+; CHECK-NEXT:   %2 = alloca float, align 4
+; CHECK-NEXT:   store float 1.000000e+00, ptr %2, align 4
+; CHECK-NEXT:   %3 = load float, ptr %2, align 4
+; CHECK-NEXT:   %4 = fcmp olt float %3, 2.000000e+00
+; CHECK-NEXT:   br label %5
+; CHECK: 5:                                                ; preds = %1
+; CHECK-NEXT:   %6 = load float, ptr %2, align 4
+; CHECK-NEXT:   %7 = fadd float %6, 1.000000e+00
+; CHECK-NEXT:   store float %7, ptr %2, align 4
+; CHECK-NEXT:   br label %8
+; CHECK: 8:                                                ; preds = %5
+; CHECK-NEXT:   br label %post-call
+; CHECK: post-call:                                        ; preds = %8, %if.then
+; CHECK-NEXT:   br label %if.end
+; CHECK: if.end:                                           ; preds = %post-call, %entry
+; CHECK-NEXT:   %9 = load i32, ptr %a, align 4
+; CHECK-NEXT:   %inc = add nsw i32 %9, 1
+; CHECK-NEXT:   store i32 %inc, ptr %a, align 4
+; CHECK-NEXT:   ret void
+; CHECK-NEXT: }


### PR DESCRIPTION
This lab work implements an LLVM inlining pass named AlexeyInliningPass. The pass identifies call instructions to functions that take no arguments and return void, and then inlines these functions into the caller. The inlining process involves cloning the function's basic blocks and instructions into the caller, updating all relevant mappings and branches accordingly. The pass is registered as a plugin and can be invoked with the name "alexey-inlining".