### PR TITLE
Lysanova Julia. Lab 4. Var 2.

### DIFF
--- a/mlir/lib/Transforms/lab4/lysanova_julia/CMakeLists.txt
+++ b/mlir/lib/Transforms/lab4/lysanova_julia/CMakeLists.txt
@@ -1,0 +1,14 @@
+set(PluginName LysanovaMathFMA_MLIR_PASS)
+
+file(GLOB_RECURSE ALL_SOURCE_FILES *.cpp *.h)
+add_llvm_pass_plugin(${PluginName}
+        ${ALL_SOURCE_FILES}
+        DEPENDS
+        intrinsics_gen
+        MLIRBuiltinLocationAttributesIncGen
+        BUILDTREE_ONLY
+        )
+
+set(MLIR_TEST_DEPENDS ${PluginName} ${MLIR_TEST_DEPENDS} PARENT_SCOPE)
+
+message(STATUS "Plugin: ${PluginName} -- BUILT")

--- a/mlir/lib/Transforms/lab4/lysanova_julia/LysanovaMathFMA.cpp
+++ b/mlir/lib/Transforms/lab4/lysanova_julia/LysanovaMathFMA.cpp
@@ -1,0 +1,69 @@
+#include "mlir/Dialect/LLVMIR/LLVMDialect.h"
+#include "mlir/IR/PatternMatch.h"
+#include "mlir/Pass/Pass.h"
+#include "mlir/Tools/Plugins/PassPlugin.h"
+
+using namespace mlir;
+
+namespace {
+
+#define PASS_NAME "lysanova-fma"
+
+class LysanovaMathFMA
+    : public PassWrapper<LysanovaMathFMA, OperationPass<LLVM::LLVMFuncOp>> {
+  StringRef getArgument() const final { return "lysanova-fma"; }
+  StringRef getDescription() const final {
+    return "Converts addition and multiplication operations to FMA in the "
+           "LLVM's dialect";
+  }
+
+  void runOnOperation() override {
+    auto funcOp = getOperation();
+
+    // Iterate over each operation inside the function.
+    funcOp.walk([&](LLVM::FAddOp addOp) {
+      // Find the preceding multiplication operation.
+      LLVM::FMulOp mulOp = addOp.getOperand(0).getDefiningOp<LLVM::FMulOp>();
+      Value otherOperand = addOp.getOperand(1);
+
+      if (!mulOp) {
+        mulOp = addOp.getOperand(1).getDefiningOp<LLVM::FMulOp>();
+        otherOperand = addOp.getOperand(0);
+        if (!mulOp)
+          return;
+      }
+
+      // Check if the multiplication operand has other users.
+      if (!mulOp.getResult().hasOneUse()) {
+        return;
+      }
+
+      // Replace addition with LLVM FMA.
+      OpBuilder builder(addOp);
+      LLVM::FMAOp fmaOp =
+          builder.create<LLVM::FMAOp>(addOp.getLoc(), mulOp.getOperand(0),
+                                      mulOp.getOperand(1), otherOperand);
+
+      // Replace all uses of addOp with the result of fmaOp.
+      addOp.replaceAllUsesWith(fmaOp.getResult());
+
+      // Erase the original operations.
+      addOp.erase();
+      mulOp.erase();
+    });
+  }
+};
+
+} // namespace
+
+MLIR_DECLARE_EXPLICIT_TYPE_ID(LysanovaMathFMA)
+MLIR_DEFINE_EXPLICIT_TYPE_ID(LysanovaMathFMA)
+
+PassPluginLibraryInfo getFMAPassPluginInfo() {
+  return {MLIR_PLUGIN_API_VERSION, PASS_NAME, LLVM_VERSION_STRING,
+          []() { PassRegistration<LysanovaMathFMA>(); }};
+}
+
+extern "C" LLVM_ATTRIBUTE_WEAK PassPluginLibraryInfo mlirGetPassPluginInfo() {
+  return getFMAPassPluginInfo();
+}

--- a/mlir/test/Transforms/lab4/lysanova_julia/main_test.mlir
+++ b/mlir/test/Transforms/lab4/lysanova_julia/main_test.mlir
@@ -1,0 +1,99 @@
+// RUN: mlir-opt -load-pass-plugin=%mlir_lib_dir/LysanovaMathFMA_MLIR_PASS%shlibext --pass-pipeline="builtin.module(llvm.func(lysanova-fma))" %s | FileCheck %s
+
+// COM: LLVM IR for further translation into MLIR was generated with the optimization key -O2
+
+module attributes {dlti.dl_spec = #dlti.dl_spec<#dlti.dl_entry<f16, dense<16> : vector<2xi32>>, #dlti.dl_entry<f64, dense<64> : vector<2xi32>>, #dlti.dl_entry<i32, dense<32> : vector<2xi32>>, #dlti.dl_entry<i16, dense<16> : vector<2xi32>>, #dlti.dl_entry<i8, dense<8> : vector<2xi32>>, #dlti.dl_entry<i1, dense<8> : vector<2xi32>>, #dlti.dl_entry<!llvm.ptr, dense<64> : vector<4xi32>>, #dlti.dl_entry<i64, dense<64> : vector<2xi32>>, #dlti.dl_entry<f80, dense<128> : vector<2xi32>>, #dlti.dl_entry<!llvm.ptr<271>, dense<32> : vector<4xi32>>, #dlti.dl_entry<!llvm.ptr<272>, dense<64> : vector<4xi32>>, #dlti.dl_entry<!llvm.ptr<270>, dense<32> : vector<4xi32>>, #dlti.dl_entry<f128, dense<128> : vector<2xi32>>, #dlti.dl_entry<"dlti.endianness", "little">, #dlti.dl_entry<"dlti.stack_alignment", 128 : i32>>} {
+  
+  // COM: double test1(double a, double b, double c) {
+  // COM:   double mul = a * b;
+  // COM:   double add = mul + c;
+  // COM:   return add;
+  // COM: }
+  llvm.func local_unnamed_addr @_Z5test1ddd(%arg0: f64 {llvm.noundef}, %arg1: f64 {llvm.noundef}, %arg2: f64 {llvm.noundef}) -> (f64 {llvm.noundef}) attributes {memory = #llvm.memory_effects<other = none, argMem = none, inaccessibleMem = none>, passthrough = ["mustprogress", "nofree", "norecurse", "nosync", "nounwind", "willreturn", ["uwtable", "2"], ["min-legal-vector-width", "0"], ["no-trapping-math", "true"], ["stack-protector-buffer-size", "8"], ["target-cpu", "x86-64"], ["target-features", "+cmov,+cx8,+fxsr,+mmx,+sse,+sse2,+x87"], ["tune-cpu", "generic"]]} {
+    %0 = llvm.fmul %arg0, %arg1  : f64
+    %1 = llvm.fadd %0, %arg2  : f64
+    llvm.return %1 : f64
+  }
+  // CHECK-LABEL: llvm.func local_unnamed_addr @_Z5test1ddd(%arg0: f64 {llvm.noundef}, %arg1: f64 {llvm.noundef}, %arg2: f64 {llvm.noundef}) -> (f64 {llvm.noundef}) attributes {memory = #llvm.memory_effects<other = none, argMem = none, inaccessibleMem = none>, passthrough = ["mustprogress", "nofree", "norecurse", "nosync", "nounwind", "willreturn", ["uwtable", "2"], ["min-legal-vector-width", "0"], ["no-trapping-math", "true"], ["stack-protector-buffer-size", "8"], ["target-cpu", "x86-64"], ["target-features", "+cmov,+cx8,+fxsr,+mmx,+sse,+sse2,+x87"], ["tune-cpu", "generic"]]} {
+  // CHECK-NEXT:   %0 = llvm.intr.fma(%arg0, %arg1, %arg2)  : (f64, f64, f64) -> f64
+  // CHECK-NEXT:   llvm.return %0 : f64
+  // CHECK-NEXT: }
+
+// =====================================================================================
+  
+  // COM: float test2(float a, float b, float c) {
+  // COM:   float mul = a * b;
+  // COM:   float add = mul + c;
+  // COM:   return add;
+  // COM: }
+  llvm.func local_unnamed_addr @_Z5test2fff(%arg0: f32 {llvm.noundef}, %arg1: f32 {llvm.noundef}, %arg2: f32 {llvm.noundef}) -> (f32 {llvm.noundef}) attributes {memory = #llvm.memory_effects<other = none, argMem = none, inaccessibleMem = none>, passthrough = ["mustprogress", "nofree", "norecurse", "nosync", "nounwind", "willreturn", ["uwtable", "2"], ["min-legal-vector-width", "0"], ["no-trapping-math", "true"], ["stack-protector-buffer-size", "8"], ["target-cpu", "x86-64"], ["target-features", "+cmov,+cx8,+fxsr,+mmx,+sse,+sse2,+x87"], ["tune-cpu", "generic"]]} {
+    %0 = llvm.fmul %arg0, %arg1  : f32
+    %1 = llvm.fadd %0, %arg2  : f32
+    llvm.return %1 : f32
+  }
+  // CHECK-LABEL: llvm.func local_unnamed_addr @_Z5test2fff(%arg0: f32 {llvm.noundef}, %arg1: f32 {llvm.noundef}, %arg2: f32 {llvm.noundef}) -> (f32 {llvm.noundef}) attributes {memory = #llvm.memory_effects<other = none, argMem = none, inaccessibleMem = none>, passthrough = ["mustprogress", "nofree", "norecurse", "nosync", "nounwind", "willreturn", ["uwtable", "2"], ["min-legal-vector-width", "0"], ["no-trapping-math", "true"], ["stack-protector-buffer-size", "8"], ["target-cpu", "x86-64"], ["target-features", "+cmov,+cx8,+fxsr,+mmx,+sse,+sse2,+x87"], ["tune-cpu", "generic"]]} {
+  // CHECK-NEXT:   %0 = llvm.intr.fma(%arg0, %arg1, %arg2)  : (f32, f32, f32) -> f32
+  // CHECK-NEXT:   llvm.return %0 : f32
+  // CHECK-NEXT: }
+
+// =====================================================================================
+  
+  // COM: double test3(double a, double b, double c) {
+  // COM:   double mul = a * b;
+  // COM:   double add = c + mul;
+  // COM:   return add;
+  // COM: }
+  llvm.func local_unnamed_addr @_Z5test3ddd(%arg0: f64 {llvm.noundef}, %arg1: f64 {llvm.noundef}, %arg2: f64 {llvm.noundef}) -> (f64 {llvm.noundef}) attributes {memory = #llvm.memory_effects<other = none, argMem = none, inaccessibleMem = none>, passthrough = ["mustprogress", "nofree", "norecurse", "nosync", "nounwind", "willreturn", ["uwtable", "2"], ["min-legal-vector-width", "0"], ["no-trapping-math", "true"], ["stack-protector-buffer-size", "8"], ["target-cpu", "x86-64"], ["target-features", "+cmov,+cx8,+fxsr,+mmx,+sse,+sse2,+x87"], ["tune-cpu", "generic"]]} {
+    %0 = llvm.fmul %arg0, %arg1  : f64
+    %1 = llvm.fadd %0, %arg2  : f64
+    llvm.return %1 : f64
+  }
+  // CHECK-LABEL: llvm.func local_unnamed_addr @_Z5test3ddd(%arg0: f64 {llvm.noundef}, %arg1: f64 {llvm.noundef}, %arg2: f64 {llvm.noundef}) -> (f64 {llvm.noundef}) attributes {memory = #llvm.memory_effects<other = none, argMem = none, inaccessibleMem = none>, passthrough = ["mustprogress", "nofree", "norecurse", "nosync", "nounwind", "willreturn", ["uwtable", "2"], ["min-legal-vector-width", "0"], ["no-trapping-math", "true"], ["stack-protector-buffer-size", "8"], ["target-cpu", "x86-64"], ["target-features", "+cmov,+cx8,+fxsr,+mmx,+sse,+sse2,+x87"], ["tune-cpu", "generic"]]} {
+  // CHECK-NEXT:   %0 = llvm.intr.fma(%arg0, %arg1, %arg2)  : (f64, f64, f64) -> f64
+  // CHECK-NEXT:   llvm.return %0 : f64
+  // CHECK-NEXT: }
+
+// =====================================================================================
+  
+  // COM: double test4(double a, double b, double c) {
+  // COM:   double mul = a * b;
+  // COM:   double add = mul + c;
+  // COM:   double use = mul + a;
+  // COM:   return add + use;
+  // COM: }
+  llvm.func local_unnamed_addr @_Z5test4ddd(%arg0: f64 {llvm.noundef}, %arg1: f64 {llvm.noundef}, %arg2: f64 {llvm.noundef}) -> (f64 {llvm.noundef}) attributes {memory = #llvm.memory_effects<other = none, argMem = none, inaccessibleMem = none>, passthrough = ["mustprogress", "nofree", "norecurse", "nosync", "nounwind", "willreturn", ["uwtable", "2"], ["min-legal-vector-width", "0"], ["no-trapping-math", "true"], ["stack-protector-buffer-size", "8"], ["target-cpu", "x86-64"], ["target-features", "+cmov,+cx8,+fxsr,+mmx,+sse,+sse2,+x87"], ["tune-cpu", "generic"]]} {
+    %0 = llvm.fmul %arg0, %arg1  : f64
+    %1 = llvm.fadd %0, %arg2  : f64
+    %2 = llvm.fadd %0, %arg0  : f64
+    %3 = llvm.fadd %1, %2  : f64
+    llvm.return %3 : f64
+  }
+  // CHECK-LABEL: llvm.func local_unnamed_addr @_Z5test4ddd(%arg0: f64 {llvm.noundef}, %arg1: f64 {llvm.noundef}, %arg2: f64 {llvm.noundef}) -> (f64 {llvm.noundef}) attributes {memory = #llvm.memory_effects<other = none, argMem = none, inaccessibleMem = none>, passthrough = ["mustprogress", "nofree", "norecurse", "nosync", "nounwind", "willreturn", ["uwtable", "2"], ["min-legal-vector-width", "0"], ["no-trapping-math", "true"], ["stack-protector-buffer-size", "8"], ["target-cpu", "x86-64"], ["target-features", "+cmov,+cx8,+fxsr,+mmx,+sse,+sse2,+x87"], ["tune-cpu", "generic"]]} {
+  // CHECK-NEXT:   %0 = llvm.fmul %arg0, %arg1  : f64
+  // CHECK-NEXT:   %1 = llvm.fadd %0, %arg2  : f64
+  // CHECK-NEXT:   %2 = llvm.fadd %0, %arg0  : f64
+  // CHECK-NEXT:   %3 = llvm.fadd %1, %2  : f64
+  // CHECK-NEXT:   llvm.return %3 : f64
+  // CHECK-NEXT: }
+
+// =====================================================================================
+  // COM: double test5(double a, double b, double c) {
+  // COM:   double mul = a * b;
+  // COM:   double add = mul + c;
+  // COM:   double use_not_mul = c + a;
+  // COM:   return add + use_not_mul;
+  // COM: }
+  llvm.func local_unnamed_addr @_Z5test5ddd(%arg0: f64 {llvm.noundef}, %arg1: f64 {llvm.noundef}, %arg2: f64 {llvm.noundef}) -> (f64 {llvm.noundef}) attributes {memory = #llvm.memory_effects<other = none, argMem = none, inaccessibleMem = none>, passthrough = ["mustprogress", "nofree", "norecurse", "nosync", "nounwind", "willreturn", ["uwtable", "2"], ["min-legal-vector-width", "0"], ["no-trapping-math", "true"], ["stack-protector-buffer-size", "8"], ["target-cpu", "x86-64"], ["target-features", "+cmov,+cx8,+fxsr,+mmx,+sse,+sse2,+x87"], ["tune-cpu", "generic"]]} {
+    %0 = llvm.fmul %arg0, %arg1  : f64
+    %1 = llvm.fadd %0, %arg2  : f64
+    %2 = llvm.fadd %arg0, %arg2  : f64
+    %3 = llvm.fadd %1, %2  : f64
+    llvm.return %3 : f64
+  }
+  // CHECK-LABEL: llvm.func local_unnamed_addr @_Z5test5ddd(%arg0: f64 {llvm.noundef}, %arg1: f64 {llvm.noundef}, %arg2: f64 {llvm.noundef}) -> (f64 {llvm.noundef}) attributes {memory = #llvm.memory_effects<other = none, argMem = none, inaccessibleMem = none>, passthrough = ["mustprogress", "nofree", "norecurse", "nosync", "nounwind", "willreturn", ["uwtable", "2"], ["min-legal-vector-width", "0"], ["no-trapping-math", "true"], ["stack-protector-buffer-size", "8"], ["target-cpu", "x86-64"], ["target-features", "+cmov,+cx8,+fxsr,+mmx,+sse,+sse2,+x87"], ["tune-cpu", "generic"]]} {
+  // CHECK-NEXT:   %0 = llvm.intr.fma(%arg0, %arg1, %arg2)  : (f64, f64, f64) -> f64
+  // CHECK-NEXT:   %1 = llvm.fadd %arg0, %arg2  : f64
+  // CHECK-NEXT:   %2 = llvm.fadd %0, %1  : f64
+  // CHECK-NEXT:   llvm.return %2 : f64
+  // CHECK-NEXT: }
+}


### PR DESCRIPTION
A `Pass` is implemented that accomplishes this task:

> Write a pass that merges multiplication and addition into a single math.fma

- Remark:
In this lab work, I worked exclusively with the `LLVM` dialect, since the `mlir-translate --import-llvm` tool generates an `LLVM` dialect `.mlir` from a `.ll` file.
I realize that I could have used `Polygeist`, which allows you to work with different dialects. But I decided to leave it as it is.